### PR TITLE
Core: Allow returning null wallpaper info

### DIFF
--- a/DailyDesktop.Core/Providers/IProvider.cs
+++ b/DailyDesktop.Core/Providers/IProvider.cs
@@ -45,7 +45,7 @@ namespace DailyDesktop.Core.Providers
         /// </summary>
         /// <param name="client">A pre-configured <see cref="HttpClient"/>.</param>
         /// <returns>The up-to-date <see cref="WallpaperInfo"/>.</returns>
-        Task<WallpaperInfo> GetWallpaperInfo(HttpClient client);
+        Task<WallpaperInfo?> GetWallpaperInfo(HttpClient client);
 
         /// <summary>
         /// Instantiates an <see cref="IProvider"/> given a <see cref="Type"/>.
@@ -91,6 +91,7 @@ namespace DailyDesktop.Core.Providers
         /// <summary>
         /// Gets an up-to-date <see cref="WallpaperInfo"/> using a pre-configured
         /// <see cref="HttpClient"/> created by <see cref="CreateHttpClient(IProvider)"/>.
+        /// If the <see cref="WallpaperInfo"/> is null, then this function throws.
         /// </summary>
         /// <param name="provider">
         /// The <see cref="IProvider"/> getting the up-to-date <see cref="WallpaperInfo"/>.
@@ -98,8 +99,30 @@ namespace DailyDesktop.Core.Providers
         /// <returns>The up-to-date <see cref="WallpaperInfo"/>.</returns>
         public static async Task<WallpaperInfo> GetWallpaperInfo(this IProvider provider)
         {
+            var wallpaperN = await provider.TryGetWallpaperInfo();
+            if (!(wallpaperN is WallpaperInfo wallpaper))
+                throw new ProviderException("Null wallpaper info.");
+
+            return wallpaper;
+        }
+
+        /// <summary>
+        /// Tries to get an up-to-date <see cref="WallpaperInfo"/> using a pre-configured
+        /// <see cref="HttpClient"/> created by <see cref="CreateHttpClient(IProvider)"/>.
+        /// If the <see cref="WallpaperInfo"/> is null, then it instead returns the given
+        /// fallback.
+        /// </summary>
+        /// <param name="provider">
+        /// The <see cref="IProvider"/> getting the up-to-date <see cref="WallpaperInfo"/>.
+        /// </param>
+        /// <param name="fallback">
+        /// The <see cref="WallpaperInfo"/> to return if the retrieved <see cref="WallpaperInfo"/> is null.
+        /// </param>
+        /// <returns>The up-to-date <see cref="WallpaperInfo"/>.</returns>
+        public static async Task<WallpaperInfo?> TryGetWallpaperInfo(this IProvider provider, WallpaperInfo? fallback = null)
+        {
             using (var client = provider.CreateHttpClient())
-                return await provider.GetWallpaperInfo(client);
+                return await provider.GetWallpaperInfo(client) ?? fallback;
         }
     }
 }

--- a/DailyDesktop.Providers.Bing/BingProvider.cs
+++ b/DailyDesktop.Providers.Bing/BingProvider.cs
@@ -23,7 +23,7 @@ namespace DailyDesktop.Providers.Bing
         public string Description => "Grabs Bing's featured Image of the Day, which can be found on Bing's home page.";
         public string SourceUri => "https://www.bing.com";
 
-        public async Task<WallpaperInfo> GetWallpaperInfo(HttpClient client)
+        public async Task<WallpaperInfo?> GetWallpaperInfo(HttpClient client)
         {
             string pageHtml = await client.GetStringAsync(SourceUri);
 

--- a/DailyDesktop.Providers.CalvinAndHobbes/CalvinAndHobbesProvider.cs
+++ b/DailyDesktop.Providers.CalvinAndHobbes/CalvinAndHobbesProvider.cs
@@ -21,7 +21,7 @@ namespace DailyDesktop.Providers.CalvinAndHobbes
         public string Description => "Fetches today's Calvin and Hobbes comic, a daily American comic strip created by cartoonist Bill Watterson from 1985 to 1995.";
         public string SourceUri => "https://www.gocomics.com/calvinandhobbes";
 
-        public async Task<WallpaperInfo> GetWallpaperInfo(HttpClient client)
+        public async Task<WallpaperInfo?> GetWallpaperInfo(HttpClient client)
         {
             string pageHtml = await client.GetStringAsync(SourceUri);
 

--- a/DailyDesktop.Providers.DeviantArt/DeviantArtProvider.cs
+++ b/DailyDesktop.Providers.DeviantArt/DeviantArtProvider.cs
@@ -27,7 +27,7 @@ namespace DailyDesktop.Providers.DeviantArt
             "highlight the best of DeviantArt from a wide variety of genres.";
         public string SourceUri => "https://www.deviantart.com/daily-deviations";
 
-        public async Task<WallpaperInfo> GetWallpaperInfo(HttpClient client)
+        public async Task<WallpaperInfo?> GetWallpaperInfo(HttpClient client)
         {
             // Search for image page URI from daily deviation page
 

--- a/DailyDesktop.Providers.FalseKnees/FalseKneesProvider.cs
+++ b/DailyDesktop.Providers.FalseKnees/FalseKneesProvider.cs
@@ -26,7 +26,7 @@ namespace DailyDesktop.Providers.FalseKnees
 
         public string SourceUri => "https://falseknees.com";
 
-        public async Task<WallpaperInfo> GetWallpaperInfo(HttpClient client)
+        public async Task<WallpaperInfo?> GetWallpaperInfo(HttpClient client)
         {
             // Scrape info from front page
 

--- a/DailyDesktop.Providers.Pixiv/PixivProvider.cs
+++ b/DailyDesktop.Providers.Pixiv/PixivProvider.cs
@@ -30,7 +30,7 @@ namespace DailyDesktop.Providers.Pixiv
             client.DefaultRequestHeaders.Referrer = new Uri("https://www.pixiv.net");
         }
 
-        public async Task<WallpaperInfo> GetWallpaperInfo(HttpClient client)
+        public async Task<WallpaperInfo?> GetWallpaperInfo(HttpClient client)
         {
             // Search for image ID of #1 illustration on daily rankings page
 

--- a/DailyDesktop.Providers.Pokemon/PokemonProvider.cs
+++ b/DailyDesktop.Providers.Pokemon/PokemonProvider.cs
@@ -26,7 +26,7 @@ namespace DailyDesktop.Providers.Pokemon
 
         public string SourceUri => "https://tcg.pokemon.com/en-us/wallpapers/";
 
-        public async Task<WallpaperInfo> GetWallpaperInfo(HttpClient client)
+        public async Task<WallpaperInfo?> GetWallpaperInfo(HttpClient client)
         {
             // Scrape info from wallpapers page
 

--- a/DailyDesktop.Providers.RedditEarthPorn/RedditEarthPornProvider.cs
+++ b/DailyDesktop.Providers.RedditEarthPorn/RedditEarthPornProvider.cs
@@ -22,7 +22,7 @@ namespace DailyDesktop.Providers.RedditEarthPorn
         public string Description => "Looks at the top post in the last 24 hours in the well-known r/EarthPorn, reddit's premiere landscape photography subreddit.";
         public string SourceUri => "https://www.reddit.com/r/EarthPorn/top/?sort=top&t=day";
 
-        public async Task<WallpaperInfo> GetWallpaperInfo(HttpClient client)
+        public async Task<WallpaperInfo?> GetWallpaperInfo(HttpClient client)
         {
             string subredditHtml = await client.GetStringAsync(SourceUri);
 

--- a/DailyDesktop.Providers.Unsplash/UnsplashProvider.cs
+++ b/DailyDesktop.Providers.Unsplash/UnsplashProvider.cs
@@ -29,7 +29,7 @@ namespace DailyDesktop.Providers.Unsplash
         public string Description => "Nabs the Photo of the Day that is currently being displayed on the front page of the website Unsplash, an online source for high-quality and freely-usable images.";
         public string SourceUri => "https://unsplash.com/collections/1459961/photo-of-the-day-(archive)";
 
-        public async Task<WallpaperInfo> GetWallpaperInfo(HttpClient client)
+        public async Task<WallpaperInfo?> GetWallpaperInfo(HttpClient client)
         {
             // Scrape info from home page
 

--- a/DailyDesktop.Providers.WikimediaCommons/WikimediaCommonsProvider.cs
+++ b/DailyDesktop.Providers.WikimediaCommons/WikimediaCommonsProvider.cs
@@ -32,7 +32,7 @@ namespace DailyDesktop.Providers.WikimediaCommons
             "a collection of Featured picture candidates.";
         public string SourceUri => "https://commons.wikimedia.org/wiki/Commons:POTD";
 
-        public async Task<WallpaperInfo> GetWallpaperInfo(HttpClient client)
+        public async Task<WallpaperInfo?> GetWallpaperInfo(HttpClient client)
         {
             // Scrape info from POTD RSS feed
 

--- a/DailyDesktop.Providers.Xkcd/XkcdProvider.cs
+++ b/DailyDesktop.Providers.Xkcd/XkcdProvider.cs
@@ -23,7 +23,7 @@ namespace DailyDesktop.Providers.Xkcd
         public string Description => "\"A webcomic of romance, sarcasm, math, and language.\"";
         public string SourceUri => "https://xkcd.com";
 
-        public async Task<WallpaperInfo> GetWallpaperInfo(HttpClient client)
+        public async Task<WallpaperInfo?> GetWallpaperInfo(HttpClient client)
         {
             string pageHtml = await client.GetStringAsync(SourceUri);
 

--- a/DailyDesktop.Task/DailyDesktop.Task.csproj
+++ b/DailyDesktop.Task/DailyDesktop.Task.csproj
@@ -4,6 +4,7 @@
     <OutputType>WinExe</OutputType>
     <TargetFramework>net6.0-windows</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/DailyDesktop.Task/Program.cs
+++ b/DailyDesktop.Task/Program.cs
@@ -50,9 +50,7 @@ namespace DailyDesktop.Task
             Type providerType = store.Add(dllPath);
             IProvider provider = IProvider.Instantiate(providerType);
 
-            string? imagePathN = await downloadWallpaper(provider, json);
-            if (!(imagePathN is string imagePath))
-                return 0;
+            string imagePath = await downloadWallpaper(provider, json);
 
             SetProcessDPIAware();
 
@@ -69,13 +67,11 @@ namespace DailyDesktop.Task
             return SystemParametersInfo(0x14, 0, tiffPath, 0x1 | 0x2);
         }
 
-        private static async Task<string?> downloadWallpaper(IProvider provider, string? jsonPath = null)
+        private static async Task<string> downloadWallpaper(IProvider provider, string? jsonPath = null)
         {
             string imagePath = Path.Combine(Path.GetTempPath(), IMAGE_FILENAME);
 
-            var infoN = await provider.TryGetWallpaperInfo();
-            if (!(infoN is WallpaperInfo info))
-                return null;
+            var info = await provider.GetWallpaperInfo();
 
             if (!string.IsNullOrWhiteSpace(jsonPath))
             {

--- a/DailyDesktop.Task/Program.cs
+++ b/DailyDesktop.Task/Program.cs
@@ -50,7 +50,9 @@ namespace DailyDesktop.Task
             Type providerType = store.Add(dllPath);
             IProvider provider = IProvider.Instantiate(providerType);
 
-            string imagePath = await downloadWallpaper(provider, json);
+            string? imagePathN = await downloadWallpaper(provider, json);
+            if (!(imagePathN is string imagePath))
+                return 0;
 
             SetProcessDPIAware();
 
@@ -67,11 +69,13 @@ namespace DailyDesktop.Task
             return SystemParametersInfo(0x14, 0, tiffPath, 0x1 | 0x2);
         }
 
-        private static async Task<string> downloadWallpaper(IProvider provider, string jsonPath = null)
+        private static async Task<string?> downloadWallpaper(IProvider provider, string? jsonPath = null)
         {
             string imagePath = Path.Combine(Path.GetTempPath(), IMAGE_FILENAME);
 
-            WallpaperInfo info = await provider.GetWallpaperInfo();
+            var infoN = await provider.TryGetWallpaperInfo();
+            if (!(infoN is WallpaperInfo info))
+                return null;
 
             if (!string.IsNullOrWhiteSpace(jsonPath))
             {

--- a/DailyDesktop.Task/Program.cs
+++ b/DailyDesktop.Task/Program.cs
@@ -12,7 +12,6 @@ using System.Runtime.InteropServices;
 using System.Text.Json;
 using System.Threading.Tasks;
 using System.Windows.Forms;
-using DailyDesktop.Core;
 using DailyDesktop.Core.Providers;
 using SuperfastBlur;
 


### PR DESCRIPTION
Sometimes there's "invalid" pictures of the day (i.e. maybe they have a video or some other form of media instead). Instead of complicating things by attempting to get the previous image, just return null so that nothing changes.

I'm not sure if this is a great idea though, because the UX of the first-time provider run could be pretty bad if no wallpaper happens to be found. One idea is to re-use what was already downloaded previously, but this would warrant some decent changes to Core (as in, moving most of the directory handling behavior to Core, and introducing some kind of Constants utility class that is used by both Desktop and Task). However, this is barely even a solution, since it'll still feel weird because it's not really the correct provider's wallpaper (it's just using whatever provider was last selected). Also, if this is (even more unluckily) the first-time run of Daily Desktop at all, then nothing will change.
