### PR TITLE
Repo: Enable nullable on all projects

### DIFF
--- a/DailyDesktop.Core/DailyDesktop.Core.csproj
+++ b/DailyDesktop.Core/DailyDesktop.Core.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0-windows</TargetFramework>
     <OutputType>Library</OutputType>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   
   <PropertyGroup>

--- a/DailyDesktop.Core/DailyDesktopCore.cs
+++ b/DailyDesktop.Core/DailyDesktopCore.cs
@@ -168,7 +168,7 @@ namespace DailyDesktop.Core
         /// Gets or sets the current provider to fetch wallpaper image URIs from
         /// in a <see cref="ProviderWrapper"/>.
         /// </summary>
-        public ProviderWrapper CurrentProvider
+        public ProviderWrapper? CurrentProvider
         {
             get
             {

--- a/DailyDesktop.Core/DailyDesktopSettings.cs
+++ b/DailyDesktop.Core/DailyDesktopSettings.cs
@@ -15,7 +15,7 @@ namespace DailyDesktop.Core
         /// <summary>
         /// Gets or sets the path of the <see cref="IProvider"/> DLL module.
         /// </summary>
-        public string DllPath { get; set; }
+        public string? DllPath { get; set; }
 
         /// <summary>
         /// Gets or sets whether wallpaper update <see cref="Microsoft.Win32.TaskScheduler.Task"/> triggers are

--- a/DailyDesktop.Core/Providers/IProvider.cs
+++ b/DailyDesktop.Core/Providers/IProvider.cs
@@ -57,7 +57,7 @@ namespace DailyDesktop.Core.Providers
         /// <exception cref="ProviderException" />
         static IProvider Instantiate(Type type)
         {
-            IProvider provider = Activator.CreateInstance(type) as IProvider;
+            IProvider? provider = Activator.CreateInstance(type) as IProvider;
 
             if (provider == null)
                 throw new ProviderException("Failed to instantiate an IProvider from the assembly.");

--- a/DailyDesktop.Core/Providers/ProviderStore.cs
+++ b/DailyDesktop.Core/Providers/ProviderStore.cs
@@ -38,7 +38,7 @@ namespace DailyDesktop.Core.Providers
         /// </summary>
         /// <param name="dllPath">The path of the <see cref="IProvider"/> DLL module to add</param>
         /// <returns>The <see cref="IProvider"/> implementation <see cref="Type"/>.</returns>
-        public Type Add(string dllPath)
+        public Type? Add(string dllPath)
         {
             if (Providers.ContainsKey(dllPath))
                 return Providers[dllPath];

--- a/DailyDesktop.Core/WallpaperInfo.cs
+++ b/DailyDesktop.Core/WallpaperInfo.cs
@@ -13,7 +13,7 @@ namespace DailyDesktop.Core
         /// <summary>
         /// Gets or sets the URI of the image file.
         /// </summary>
-        public string ImageUri { get; set; }
+        public string? ImageUri { get; set; }
 
         /// <summary>
         /// Gets or sets the date when the image was downloaded.
@@ -24,28 +24,28 @@ namespace DailyDesktop.Core
         /// Gets or sets the author of the work (i.e. the illustrator,
         /// photographer, painter, etc.)
         /// </summary>
-        public string Author { get; set; }
+        public string? Author { get; set; }
 
         /// <summary>
         /// Gets or sets a URI to the <see cref="Author"/>. Usually a URL to
         /// the author's website or profile page.
         /// </summary>
-        public string AuthorUri { get; set; }
+        public string? AuthorUri { get; set; }
 
         /// <summary>
         /// Gets or sets the title of the work.
         /// </summary>
-        public string Title { get; set; }
+        public string? Title { get; set; }
 
         /// <summary>
         /// Gets or sets a URI to the work. Usually a URL to the image's page on
         /// the source website where it was downloaded from.
         /// </summary>
-        public string TitleUri { get; set; }
+        public string? TitleUri { get; set; }
 
         /// <summary>
         /// Gets or sets a description for the work.
         /// </summary>
-        public string Description { get; set; }
+        public string? Description { get; set; }
     }
 }

--- a/DailyDesktop.Desktop/DailyDesktop.Desktop.csproj
+++ b/DailyDesktop.Desktop/DailyDesktop.Desktop.csproj
@@ -6,6 +6,7 @@
     <UseWindowsForms>true</UseWindowsForms>
     <ApplicationIcon>Icon.ico</ApplicationIcon>
     <AssemblyName>DailyDesktop.Desktop</AssemblyName>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/DailyDesktop.Desktop/MainForm.cs
+++ b/DailyDesktop.Desktop/MainForm.cs
@@ -53,13 +53,17 @@ namespace DailyDesktop.Desktop
             overviewRichTextBox.LinkClicked += overviewRichTextBox_LinkClicked;
             licenseRichTextBox.LinkClicked += licenseRichTextBox_LinkClicked;
 
-            string baseDir = new Uri(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)).AbsolutePath;
+            string? baseDirName = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            if (string.IsNullOrWhiteSpace(baseDirName))
+                throw new InvalidOperationException("Assembly directory could not be found.");
+
+            string baseDir = new Uri(baseDirName).AbsolutePath;
             string licenseUri = $"file:///{baseDir}/{LICENSE_FILENAME}";
             string eulaUri = $"file:///{baseDir}/{EULA_FILENAME}";
             licenseRichTextBox.Text = string.Format(licenseRichTextBox.Text, licenseUri, eulaUri);
         }
 
-        private void openUri(string uri)
+        private void openUri(string? uri)
         {
             if (string.IsNullOrWhiteSpace(uri))
                 return;
@@ -73,7 +77,7 @@ namespace DailyDesktop.Desktop
             Process.Start(psi);
         }
 
-        private void MainForm_Load(object sender, EventArgs e)
+        private void MainForm_Load(object? _, EventArgs e)
         {
             repopulateProviderComboBox();
             if (core.CurrentProvider != null)
@@ -95,15 +99,14 @@ namespace DailyDesktop.Desktop
             stateBackgroundWorker.RunWorkerAsync();
         }
 
-        private void MainForm_FormClosing(object sender, EventArgs e)
+        private void MainForm_FormClosing(object? _, EventArgs e)
         {
             stateBackgroundWorker.CancelAsync();
         }
 
-        private void providerComboBox_SelectedIndexChanged(object sender, EventArgs e)
+        private void providerComboBox_SelectedIndexChanged(object? _, EventArgs e)
         {
-            ProviderWrapper item = providerComboBox.SelectedItem as ProviderWrapper;
-            core.CurrentProvider = item;
+            core.CurrentProvider = providerComboBox.SelectedItem as ProviderWrapper;
             updateProviderInfo();
         }
 
@@ -120,13 +123,15 @@ namespace DailyDesktop.Desktop
         // tbh idek why i did this O(n^2) isn't even that unreasonable...
         private void repopulateProviderComboBox()
         {
-            Dictionary<string, int> items = new Dictionary<string, int>();
-            Dictionary<string, Type> providers = core.Providers;
+            var items = new Dictionary<string, int>();
+            var providers = core.Providers;
 
             for (int i = 0; i < providerComboBox.Items.Count; i++)
             {
-                ProviderWrapper provider = providerComboBox.Items[i] as ProviderWrapper;
-                items.Add(provider.DllPath, i);
+                var provider = providerComboBox.Items[i] as ProviderWrapper;
+
+                if (provider != null)
+                    items.Add(provider.DllPath, i);
             }
 
             foreach (var keyVal in providers)
@@ -134,8 +139,8 @@ namespace DailyDesktop.Desktop
                 if (!items.ContainsKey(keyVal.Key))
                     try
                     {
-                        IProvider provider = IProvider.Instantiate(keyVal.Value);
-                        ProviderWrapper item = new ProviderWrapper(keyVal.Key, provider);
+                        var provider = IProvider.Instantiate(keyVal.Value);
+                        var item = new ProviderWrapper(keyVal.Key, provider);
                         providerComboBox.Items.Add(item);
                     }
                     catch (ProviderException ex)
@@ -151,29 +156,29 @@ namespace DailyDesktop.Desktop
             }
         }
 
-        private void providerComboBox_DropDown(object sender, EventArgs e) => repopulateProviderComboBox();
+        private void providerComboBox_DropDown(object? _, EventArgs e) => repopulateProviderComboBox();
 
-        private void providerSourceLinkLabel_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e) => openUri(providerSourceLinkLabel.Text);
+        private void providerSourceLinkLabel_LinkClicked(object? _, LinkLabelLinkClickedEventArgs e) => openUri(providerSourceLinkLabel.Text);
 
-        private void optionsUpdateTimePicker_ValueChanged(object sender, EventArgs e)
+        private void optionsUpdateTimePicker_ValueChanged(object? _, EventArgs e)
         {
             core.UpdateTime = optionsUpdateTimePicker.Value;
         }
 
-        private void optionsEnabledCheckBox_CheckedChanged(object sender, EventArgs e)
+        private void optionsEnabledCheckBox_CheckedChanged(object? _, EventArgs e)
         {
             core.Enabled = optionsEnabledCheckBox.Checked;
             optionsUpdateTimePicker.Enabled = optionsEnabledCheckBox.Checked;
         }
 
-        private void optionsUpdateWallpaperButton_Click(object sender, EventArgs e)
+        private void optionsUpdateWallpaperButton_Click(object? _, EventArgs e)
         {
             core.UpdateWallpaper();
         }
 
-        private void optionsProvidersDirectoryButton_Click(object sender, EventArgs e) => openUri(core.ProvidersDirectory);
+        private void optionsProvidersDirectoryButton_Click(object? _, EventArgs e) => openUri(core.ProvidersDirectory);
 
-        private void optionsBlurStrengthTrackBar_Scroll(object sender, EventArgs e)
+        private void optionsBlurStrengthTrackBar_Scroll(object? _, EventArgs e)
         {
             core.BlurStrength = optionsBlurStrengthTrackBar.Value;
             updateBlurStrengthToolTip();
@@ -185,20 +190,20 @@ namespace DailyDesktop.Desktop
             mainToolTip.SetToolTip(optionsBlurStrengthTrackBar, strength);
         }
 
-        private void optionsBlurredFitCheckBox_CheckedChanged(object sender, EventArgs e)
+        private void optionsBlurredFitCheckBox_CheckedChanged(object? _, EventArgs e)
         {
             core.DoBlurredFit = optionsBlurredFitCheckBox.Checked;
             optionsBlurStrengthTrackBar.Enabled = optionsBlurredFitCheckBox.Checked;
         }
 
-        private void optionsResizeCheckBox_CheckedChanged(object sender, EventArgs e)
+        private void optionsResizeCheckBox_CheckedChanged(object? _, EventArgs e)
         {
             core.DoResize = optionsResizeCheckBox.Checked;
         }
 
-        private void wallpaperTitleLinkLabel_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e) => openUri(wallpaper.TitleUri);
+        private void wallpaperTitleLinkLabel_LinkClicked(object? _, LinkLabelLinkClickedEventArgs e) => openUri(wallpaper.TitleUri);
 
-        private void wallpaperAuthorLinkLabel_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e) => openUri(wallpaper.AuthorUri);
+        private void wallpaperAuthorLinkLabel_LinkClicked(object? _, LinkLabelLinkClickedEventArgs e) => openUri(wallpaper.AuthorUri);
 
         private void updateWallpaperInfo()
         {
@@ -213,10 +218,9 @@ namespace DailyDesktop.Desktop
                 string text = wallpaper.Description ?? NULL_DESCRIPTION;
                 wallpaperDescriptionRichTextBox.Text = Regex.Replace(text, "(?<=[^\r])\n", "\r\n");
 
-                Uri temp;
-                wallpaperTitleLinkLabel.Links[0].Enabled = Uri.TryCreate(wallpaper.TitleUri, UriKind.Absolute, out temp);
+                wallpaperTitleLinkLabel.Links[0].Enabled = Uri.TryCreate(wallpaper.TitleUri, UriKind.Absolute, out _);
                 wallpaperTitleLinkLabel.TabStop = wallpaperTitleLinkLabel.Links[0].Enabled;
-                wallpaperAuthorLinkLabel.Links[0].Enabled = Uri.TryCreate(wallpaper.AuthorUri, UriKind.Absolute, out temp);
+                wallpaperAuthorLinkLabel.Links[0].Enabled = Uri.TryCreate(wallpaper.AuthorUri, UriKind.Absolute, out _);
                 wallpaperAuthorLinkLabel.TabStop = wallpaperAuthorLinkLabel.Links[0].Enabled;
             }
             catch (Exception e) when (e is JsonException or FileNotFoundException)
@@ -233,7 +237,7 @@ namespace DailyDesktop.Desktop
             }
         }
 
-        private void stateBackgroundWorker_DoWork(object sender, EventArgs e)
+        private void stateBackgroundWorker_DoWork(object? _, EventArgs e)
         {
             while (!stateBackgroundWorker.CancellationPending)
             {
@@ -245,7 +249,7 @@ namespace DailyDesktop.Desktop
             }
         }
 
-        private void stateBackgroundWorker_ProgressChanged(object sender, ProgressChangedEventArgs e)
+        private void stateBackgroundWorker_ProgressChanged(object? _, ProgressChangedEventArgs e)
         {
             TaskState state = (TaskState)e.ProgressPercentage;
             stateLabel.Text = state.ToString();
@@ -254,15 +258,15 @@ namespace DailyDesktop.Desktop
                 updateWallpaperInfo();
         }
 
-        private void okButton_Click(object sender, EventArgs e)
+        private void okButton_Click(object? _, EventArgs e)
         {
             Application.Exit();
         }
 
-        private void wallpaperDescriptionRichTextBox_LinkClicked(object sender, LinkClickedEventArgs e) => openUri(e.LinkText);
+        private void wallpaperDescriptionRichTextBox_LinkClicked(object? _, LinkClickedEventArgs e) => openUri(e.LinkText);
 
-        private void overviewRichTextBox_LinkClicked(object sender, LinkClickedEventArgs e) => openUri(e.LinkText);
+        private void overviewRichTextBox_LinkClicked(object? _, LinkClickedEventArgs e) => openUri(e.LinkText);
 
-        private void licenseRichTextBox_LinkClicked(object sender, LinkClickedEventArgs e) => openUri(e.LinkText);
+        private void licenseRichTextBox_LinkClicked(object? _, LinkClickedEventArgs e) => openUri(e.LinkText);
     }
 }

--- a/DailyDesktop.Desktop/MainForm.cs
+++ b/DailyDesktop.Desktop/MainForm.cs
@@ -53,9 +53,8 @@ namespace DailyDesktop.Desktop
             overviewRichTextBox.LinkClicked += overviewRichTextBox_LinkClicked;
             licenseRichTextBox.LinkClicked += licenseRichTextBox_LinkClicked;
 
-            string? baseDirName = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-            if (string.IsNullOrWhiteSpace(baseDirName))
-                throw new InvalidOperationException("Assembly directory could not be found.");
+            string baseDirName = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)
+                ?? throw new NullReferenceException("Assembly directory could not be found.");
 
             string baseDir = new Uri(baseDirName).AbsolutePath;
             string licenseUri = $"file:///{baseDir}/{LICENSE_FILENAME}";

--- a/DailyDesktop.Providers.Bing/DailyDesktop.Providers.Bing.csproj
+++ b/DailyDesktop.Providers.Bing/DailyDesktop.Providers.Bing.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0-windows</TargetFramework>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/DailyDesktop.Providers.CalvinAndHobbes/DailyDesktop.Providers.CalvinAndHobbes.csproj
+++ b/DailyDesktop.Providers.CalvinAndHobbes/DailyDesktop.Providers.CalvinAndHobbes.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0-windows</TargetFramework>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/DailyDesktop.Providers.DeviantArt/DailyDesktop.Providers.DeviantArt.csproj
+++ b/DailyDesktop.Providers.DeviantArt/DailyDesktop.Providers.DeviantArt.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0-windows</TargetFramework>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/DailyDesktop.Providers.DeviantArt/DeviantArtProvider.cs
+++ b/DailyDesktop.Providers.DeviantArt/DeviantArtProvider.cs
@@ -45,11 +45,11 @@ namespace DailyDesktop.Providers.DeviantArt
             if (string.IsNullOrWhiteSpace(imageUri))
                 throw new ProviderException("Didn't find an image URI.");
 
-            string credit = Regex.Match(imagePageHtml, CREDIT_PATTERN).Value ?? null;
+            string credit = Regex.Match(imagePageHtml, CREDIT_PATTERN).Value;
             string author = Regex.Match(credit, AUTHOR_PATTERN).Value;
             string authorUri = "https://www.deviantart.com/" + WebUtility.UrlEncode(author);
             string title = Regex.Match(credit, TITLE_PATTERN).Value;
-            string description = Regex.Replace(WebUtility.HtmlDecode(Regex.Match(imagePageHtml, DESCRIPTION_PATTERN).Value), "<([^<>]*?)>", "");
+            string? description = Regex.Replace(WebUtility.HtmlDecode(Regex.Match(imagePageHtml, DESCRIPTION_PATTERN).Value), "<([^<>]*?)>", "");
             if (string.IsNullOrWhiteSpace(description))
                 description = null;
 

--- a/DailyDesktop.Providers.FalseKnees/DailyDesktop.Providers.FalseKnees.csproj
+++ b/DailyDesktop.Providers.FalseKnees/DailyDesktop.Providers.FalseKnees.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0-windows</TargetFramework>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/DailyDesktop.Providers.Pixiv/DailyDesktop.Providers.Pixiv.csproj
+++ b/DailyDesktop.Providers.Pixiv/DailyDesktop.Providers.Pixiv.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0-windows</TargetFramework>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/DailyDesktop.Providers.Pokemon/DailyDesktop.Providers.Pokemon.csproj
+++ b/DailyDesktop.Providers.Pokemon/DailyDesktop.Providers.Pokemon.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0-windows</TargetFramework>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/DailyDesktop.Providers.Pokemon/PokemonProvider.cs
+++ b/DailyDesktop.Providers.Pokemon/PokemonProvider.cs
@@ -42,7 +42,7 @@ namespace DailyDesktop.Providers.Pokemon
 
             var response = await client.GetAsync("https://api.pokemontcg.io/v2/cards?q=name:\"" + title + "\"");
 
-            string description;
+            string? description;
             if (response.IsSuccessStatusCode)
             {
                 string content = await response.Content.ReadAsStringAsync();

--- a/DailyDesktop.Providers.RedditEarthPorn/DailyDesktop.Providers.RedditEarthPorn.csproj
+++ b/DailyDesktop.Providers.RedditEarthPorn/DailyDesktop.Providers.RedditEarthPorn.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0-windows</TargetFramework>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/DailyDesktop.Providers.Unsplash/DailyDesktop.Providers.Unsplash.csproj
+++ b/DailyDesktop.Providers.Unsplash/DailyDesktop.Providers.Unsplash.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0-windows</TargetFramework>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/DailyDesktop.Providers.WikimediaCommons/DailyDesktop.Providers.WikimediaCommons.csproj
+++ b/DailyDesktop.Providers.WikimediaCommons/DailyDesktop.Providers.WikimediaCommons.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0-windows</TargetFramework>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/DailyDesktop.Providers.Xkcd/DailyDesktop.Providers.Xkcd.csproj
+++ b/DailyDesktop.Providers.Xkcd/DailyDesktop.Providers.Xkcd.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0-windows</TargetFramework>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/DailyDesktop.Task/DailyDesktop.Task.csproj
+++ b/DailyDesktop.Task/DailyDesktop.Task.csproj
@@ -4,6 +4,7 @@
     <OutputType>WinExe</OutputType>
     <TargetFramework>net6.0-windows</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/DailyDesktop.Task/Program.cs
+++ b/DailyDesktop.Task/Program.cs
@@ -46,9 +46,9 @@ namespace DailyDesktop.Task
             if (string.IsNullOrWhiteSpace(dllPath))
                 throw new ProviderException("Missing IProvider DLL module path");
 
-            ProviderStore store = new ProviderStore();
-            Type providerType = store.Add(dllPath);
-            IProvider provider = IProvider.Instantiate(providerType);
+            var store = new ProviderStore();
+            var providerType = store.Add(dllPath) ?? throw new NullReferenceException("Null provider type");
+            var provider = IProvider.Instantiate(providerType);
 
             string imagePath = await downloadWallpaper(provider, json);
 
@@ -67,7 +67,7 @@ namespace DailyDesktop.Task
             return SystemParametersInfo(0x14, 0, tiffPath, 0x1 | 0x2);
         }
 
-        private static async Task<string> downloadWallpaper(IProvider provider, string jsonPath = null)
+        private static async Task<string> downloadWallpaper(IProvider provider, string? jsonPath = null)
         {
             string imagePath = Path.Combine(Path.GetTempPath(), IMAGE_FILENAME);
 

--- a/DailyDesktop.Tests/DailyDesktop.Tests.csproj
+++ b/DailyDesktop.Tests/DailyDesktop.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0-windows</TargetFramework>
+    <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/DailyDesktop.Tests/TestProviders.cs
+++ b/DailyDesktop.Tests/TestProviders.cs
@@ -22,16 +22,7 @@ namespace DailyDesktop.Tests
     {
         public TestContext? TestContext { get; set; }
 
-        private TestContext context
-        {
-            get
-            {
-                if (TestContext == null)
-                    throw new NullReferenceException("Null test context");
-
-                return TestContext;
-            }
-        }
+        private TestContext testContext => TestContext ?? throw new NullReferenceException("Null test context");
 
         [TestMethod]
         public async Task TestBing()
@@ -39,11 +30,11 @@ namespace DailyDesktop.Tests
             var provider = new BingProvider();
             var wallpaper = await provider.GetWallpaperInfo();
 
-            context.WriteLine("Author: " + wallpaper.Author);
-            context.WriteLine("Description: " + wallpaper.Description);
-            context.WriteLine("Image URI: " + wallpaper.ImageUri);
-            context.WriteLine("Title: " + wallpaper.Title);
-            context.WriteLine("Title Uri: " + wallpaper.TitleUri);
+            testContext.WriteLine("Author: " + wallpaper.Author);
+            testContext.WriteLine("Description: " + wallpaper.Description);
+            testContext.WriteLine("Image URI: " + wallpaper.ImageUri);
+            testContext.WriteLine("Title: " + wallpaper.Title);
+            testContext.WriteLine("Title Uri: " + wallpaper.TitleUri);
 
             Assert.IsFalse(string.IsNullOrWhiteSpace(wallpaper.Author), "Null/whitespace author.");
             Assert.IsFalse(string.IsNullOrWhiteSpace(wallpaper.Description), "Null/whitespace description.");
@@ -58,8 +49,8 @@ namespace DailyDesktop.Tests
             var provider = new CalvinAndHobbesProvider();
             var wallpaper = await provider.GetWallpaperInfo();
 
-            context.WriteLine("Image URI: " + wallpaper.ImageUri);
-            context.WriteLine("Title Uri: " + wallpaper.TitleUri);
+            testContext.WriteLine("Image URI: " + wallpaper.ImageUri);
+            testContext.WriteLine("Title Uri: " + wallpaper.TitleUri);
 
             Assert.IsFalse(string.IsNullOrWhiteSpace(wallpaper.ImageUri), "Null/whitespace image URI!");
             Assert.IsFalse(string.IsNullOrWhiteSpace(wallpaper.TitleUri), "Null/whitespace title URI.");
@@ -92,10 +83,10 @@ namespace DailyDesktop.Tests
             var provider = new FalseKneesProvider();
             var wallpaper = await provider.GetWallpaperInfo();
 
-            context.WriteLine("Description: " + wallpaper.Description);
-            context.WriteLine("Image URI: " + wallpaper.ImageUri);
-            context.WriteLine("Title: " + wallpaper.Title);
-            context.WriteLine("Title Uri: " + wallpaper.TitleUri);
+            testContext.WriteLine("Description: " + wallpaper.Description);
+            testContext.WriteLine("Image URI: " + wallpaper.ImageUri);
+            testContext.WriteLine("Title: " + wallpaper.Title);
+            testContext.WriteLine("Title Uri: " + wallpaper.TitleUri);
 
             Assert.IsFalse(string.IsNullOrWhiteSpace(wallpaper.Description), "Null/whitespace description.");
             Assert.IsFalse(string.IsNullOrWhiteSpace(wallpaper.ImageUri), "Null/whitespace image URI!");
@@ -129,12 +120,12 @@ namespace DailyDesktop.Tests
             var provider = new PixivProvider();
             var wallpaper = await provider.GetWallpaperInfo();
 
-            context.WriteLine("Author: " + wallpaper.Author);
-            context.WriteLine("Author URI: " + wallpaper.AuthorUri);
-            context.WriteLine("Description: " + wallpaper.Description);
-            context.WriteLine("Image URI: " + wallpaper.ImageUri);
-            context.WriteLine("Title: " + wallpaper.Title);
-            context.WriteLine("Title Uri: " + wallpaper.TitleUri);
+            testContext.WriteLine("Author: " + wallpaper.Author);
+            testContext.WriteLine("Author URI: " + wallpaper.AuthorUri);
+            testContext.WriteLine("Description: " + wallpaper.Description);
+            testContext.WriteLine("Image URI: " + wallpaper.ImageUri);
+            testContext.WriteLine("Title: " + wallpaper.Title);
+            testContext.WriteLine("Title Uri: " + wallpaper.TitleUri);
 
             Assert.IsFalse(string.IsNullOrWhiteSpace(wallpaper.Author), "Null/whitespace author.");
             Assert.IsFalse(string.IsNullOrWhiteSpace(wallpaper.AuthorUri), "Null/whitespace author URI.");
@@ -150,10 +141,10 @@ namespace DailyDesktop.Tests
             var provider = new PokemonProvider();
             var wallpaper = await provider.GetWallpaperInfo();
 
-            context.WriteLine("Description: " + wallpaper.Description);
-            context.WriteLine("Image URI: " + wallpaper.ImageUri);
-            context.WriteLine("Title: " + wallpaper.Title);
-            context.WriteLine("Title Uri: " + wallpaper.TitleUri);
+            testContext.WriteLine("Description: " + wallpaper.Description);
+            testContext.WriteLine("Image URI: " + wallpaper.ImageUri);
+            testContext.WriteLine("Title: " + wallpaper.Title);
+            testContext.WriteLine("Title Uri: " + wallpaper.TitleUri);
 
             Assert.IsFalse(string.IsNullOrWhiteSpace(wallpaper.Description), "Null/whitespace description.");
             Assert.IsFalse(string.IsNullOrWhiteSpace(wallpaper.ImageUri), "Null/whitespace image URI!");
@@ -167,11 +158,11 @@ namespace DailyDesktop.Tests
             var provider = new RedditEarthPornProvider();
             var wallpaper = await provider.GetWallpaperInfo();
 
-            context.WriteLine("Author: " + wallpaper.Author);
-            context.WriteLine("Author URI: " + wallpaper.AuthorUri);
-            context.WriteLine("Description: " + wallpaper.Description);
-            context.WriteLine("Image URI: " + wallpaper.ImageUri);
-            context.WriteLine("Title Uri: " + wallpaper.TitleUri);
+            testContext.WriteLine("Author: " + wallpaper.Author);
+            testContext.WriteLine("Author URI: " + wallpaper.AuthorUri);
+            testContext.WriteLine("Description: " + wallpaper.Description);
+            testContext.WriteLine("Image URI: " + wallpaper.ImageUri);
+            testContext.WriteLine("Title Uri: " + wallpaper.TitleUri);
 
             Assert.IsFalse(string.IsNullOrWhiteSpace(wallpaper.Author), "Null/whitespace author.");
             Assert.IsFalse(string.IsNullOrWhiteSpace(wallpaper.AuthorUri), "Null/whitespace author URI.");
@@ -186,12 +177,12 @@ namespace DailyDesktop.Tests
             var provider = new UnsplashProvider();
             var wallpaper = await provider.GetWallpaperInfo();
 
-            context.WriteLine("Author: " + wallpaper.Author);
-            context.WriteLine("Author URI: " + wallpaper.AuthorUri);
-            context.WriteLine("Description: " + wallpaper.Description);
-            context.WriteLine("Image URI: " + wallpaper.ImageUri);
-            context.WriteLine("Title: " + wallpaper.Title);
-            context.WriteLine("Title Uri: " + wallpaper.TitleUri);
+            testContext.WriteLine("Author: " + wallpaper.Author);
+            testContext.WriteLine("Author URI: " + wallpaper.AuthorUri);
+            testContext.WriteLine("Description: " + wallpaper.Description);
+            testContext.WriteLine("Image URI: " + wallpaper.ImageUri);
+            testContext.WriteLine("Title: " + wallpaper.Title);
+            testContext.WriteLine("Title Uri: " + wallpaper.TitleUri);
 
             Assert.IsFalse(string.IsNullOrWhiteSpace(wallpaper.Author), "Null/whitespace author.");
             Assert.IsFalse(string.IsNullOrWhiteSpace(wallpaper.AuthorUri), "Null/whitespace author URI.");
@@ -207,12 +198,12 @@ namespace DailyDesktop.Tests
             var provider = new WikimediaCommonsProvider();
             var wallpaper = await provider.GetWallpaperInfo();
 
-            context.WriteLine("Author: " + wallpaper.Author);
-            context.WriteLine("Author URI: " + wallpaper.AuthorUri);
-            context.WriteLine("Description: " + wallpaper.Description);
-            context.WriteLine("Image URI: " + wallpaper.ImageUri);
-            context.WriteLine("Title: " + wallpaper.Title);
-            context.WriteLine("Title Uri: " + wallpaper.TitleUri);
+            testContext.WriteLine("Author: " + wallpaper.Author);
+            testContext.WriteLine("Author URI: " + wallpaper.AuthorUri);
+            testContext.WriteLine("Description: " + wallpaper.Description);
+            testContext.WriteLine("Image URI: " + wallpaper.ImageUri);
+            testContext.WriteLine("Title: " + wallpaper.Title);
+            testContext.WriteLine("Title Uri: " + wallpaper.TitleUri);
 
             Assert.IsFalse(string.IsNullOrWhiteSpace(wallpaper.Author), "Null/whitespace author.");
             Assert.IsFalse(string.IsNullOrWhiteSpace(wallpaper.AuthorUri), "Null/whitespace author URI.");
@@ -228,9 +219,9 @@ namespace DailyDesktop.Tests
             var provider = new XkcdProvider();
             var wallpaper = await provider.GetWallpaperInfo();
 
-            context.WriteLine("Image URI: " + wallpaper.ImageUri);
-            context.WriteLine("Title: " + wallpaper.Title);
-            context.WriteLine("Title Uri: " + wallpaper.TitleUri);
+            testContext.WriteLine("Image URI: " + wallpaper.ImageUri);
+            testContext.WriteLine("Title: " + wallpaper.Title);
+            testContext.WriteLine("Title Uri: " + wallpaper.TitleUri);
 
             Assert.IsFalse(string.IsNullOrWhiteSpace(wallpaper.ImageUri), "Null/whitespace image URI!");
             Assert.IsFalse(string.IsNullOrWhiteSpace(wallpaper.Title), "Null/whitespace title.");

--- a/DailyDesktop.Tests/TestProviders.cs
+++ b/DailyDesktop.Tests/TestProviders.cs
@@ -20,9 +20,7 @@ namespace DailyDesktop.Tests
     [TestClass]
     public class TestProviders
     {
-        public TestContext? TestContext { get; set; }
-
-        private TestContext testContext => TestContext ?? throw new NullReferenceException("Null test context");
+        public TestContext TestContext { get; set; } = null!;
 
         [TestMethod]
         public async Task TestBing()
@@ -30,11 +28,11 @@ namespace DailyDesktop.Tests
             var provider = new BingProvider();
             var wallpaper = await provider.GetWallpaperInfo();
 
-            testContext.WriteLine("Author: " + wallpaper.Author);
-            testContext.WriteLine("Description: " + wallpaper.Description);
-            testContext.WriteLine("Image URI: " + wallpaper.ImageUri);
-            testContext.WriteLine("Title: " + wallpaper.Title);
-            testContext.WriteLine("Title Uri: " + wallpaper.TitleUri);
+            TestContext.WriteLine("Author: " + wallpaper.Author);
+            TestContext.WriteLine("Description: " + wallpaper.Description);
+            TestContext.WriteLine("Image URI: " + wallpaper.ImageUri);
+            TestContext.WriteLine("Title: " + wallpaper.Title);
+            TestContext.WriteLine("Title Uri: " + wallpaper.TitleUri);
 
             Assert.IsFalse(string.IsNullOrWhiteSpace(wallpaper.Author), "Null/whitespace author.");
             Assert.IsFalse(string.IsNullOrWhiteSpace(wallpaper.Description), "Null/whitespace description.");
@@ -49,8 +47,8 @@ namespace DailyDesktop.Tests
             var provider = new CalvinAndHobbesProvider();
             var wallpaper = await provider.GetWallpaperInfo();
 
-            testContext.WriteLine("Image URI: " + wallpaper.ImageUri);
-            testContext.WriteLine("Title Uri: " + wallpaper.TitleUri);
+            TestContext.WriteLine("Image URI: " + wallpaper.ImageUri);
+            TestContext.WriteLine("Title Uri: " + wallpaper.TitleUri);
 
             Assert.IsFalse(string.IsNullOrWhiteSpace(wallpaper.ImageUri), "Null/whitespace image URI!");
             Assert.IsFalse(string.IsNullOrWhiteSpace(wallpaper.TitleUri), "Null/whitespace title URI.");
@@ -83,10 +81,10 @@ namespace DailyDesktop.Tests
             var provider = new FalseKneesProvider();
             var wallpaper = await provider.GetWallpaperInfo();
 
-            testContext.WriteLine("Description: " + wallpaper.Description);
-            testContext.WriteLine("Image URI: " + wallpaper.ImageUri);
-            testContext.WriteLine("Title: " + wallpaper.Title);
-            testContext.WriteLine("Title Uri: " + wallpaper.TitleUri);
+            TestContext.WriteLine("Description: " + wallpaper.Description);
+            TestContext.WriteLine("Image URI: " + wallpaper.ImageUri);
+            TestContext.WriteLine("Title: " + wallpaper.Title);
+            TestContext.WriteLine("Title Uri: " + wallpaper.TitleUri);
 
             Assert.IsFalse(string.IsNullOrWhiteSpace(wallpaper.Description), "Null/whitespace description.");
             Assert.IsFalse(string.IsNullOrWhiteSpace(wallpaper.ImageUri), "Null/whitespace image URI!");
@@ -120,12 +118,12 @@ namespace DailyDesktop.Tests
             var provider = new PixivProvider();
             var wallpaper = await provider.GetWallpaperInfo();
 
-            testContext.WriteLine("Author: " + wallpaper.Author);
-            testContext.WriteLine("Author URI: " + wallpaper.AuthorUri);
-            testContext.WriteLine("Description: " + wallpaper.Description);
-            testContext.WriteLine("Image URI: " + wallpaper.ImageUri);
-            testContext.WriteLine("Title: " + wallpaper.Title);
-            testContext.WriteLine("Title Uri: " + wallpaper.TitleUri);
+            TestContext.WriteLine("Author: " + wallpaper.Author);
+            TestContext.WriteLine("Author URI: " + wallpaper.AuthorUri);
+            TestContext.WriteLine("Description: " + wallpaper.Description);
+            TestContext.WriteLine("Image URI: " + wallpaper.ImageUri);
+            TestContext.WriteLine("Title: " + wallpaper.Title);
+            TestContext.WriteLine("Title Uri: " + wallpaper.TitleUri);
 
             Assert.IsFalse(string.IsNullOrWhiteSpace(wallpaper.Author), "Null/whitespace author.");
             Assert.IsFalse(string.IsNullOrWhiteSpace(wallpaper.AuthorUri), "Null/whitespace author URI.");
@@ -141,10 +139,10 @@ namespace DailyDesktop.Tests
             var provider = new PokemonProvider();
             var wallpaper = await provider.GetWallpaperInfo();
 
-            testContext.WriteLine("Description: " + wallpaper.Description);
-            testContext.WriteLine("Image URI: " + wallpaper.ImageUri);
-            testContext.WriteLine("Title: " + wallpaper.Title);
-            testContext.WriteLine("Title Uri: " + wallpaper.TitleUri);
+            TestContext.WriteLine("Description: " + wallpaper.Description);
+            TestContext.WriteLine("Image URI: " + wallpaper.ImageUri);
+            TestContext.WriteLine("Title: " + wallpaper.Title);
+            TestContext.WriteLine("Title Uri: " + wallpaper.TitleUri);
 
             Assert.IsFalse(string.IsNullOrWhiteSpace(wallpaper.Description), "Null/whitespace description.");
             Assert.IsFalse(string.IsNullOrWhiteSpace(wallpaper.ImageUri), "Null/whitespace image URI!");
@@ -158,11 +156,11 @@ namespace DailyDesktop.Tests
             var provider = new RedditEarthPornProvider();
             var wallpaper = await provider.GetWallpaperInfo();
 
-            testContext.WriteLine("Author: " + wallpaper.Author);
-            testContext.WriteLine("Author URI: " + wallpaper.AuthorUri);
-            testContext.WriteLine("Description: " + wallpaper.Description);
-            testContext.WriteLine("Image URI: " + wallpaper.ImageUri);
-            testContext.WriteLine("Title Uri: " + wallpaper.TitleUri);
+            TestContext.WriteLine("Author: " + wallpaper.Author);
+            TestContext.WriteLine("Author URI: " + wallpaper.AuthorUri);
+            TestContext.WriteLine("Description: " + wallpaper.Description);
+            TestContext.WriteLine("Image URI: " + wallpaper.ImageUri);
+            TestContext.WriteLine("Title Uri: " + wallpaper.TitleUri);
 
             Assert.IsFalse(string.IsNullOrWhiteSpace(wallpaper.Author), "Null/whitespace author.");
             Assert.IsFalse(string.IsNullOrWhiteSpace(wallpaper.AuthorUri), "Null/whitespace author URI.");
@@ -177,12 +175,12 @@ namespace DailyDesktop.Tests
             var provider = new UnsplashProvider();
             var wallpaper = await provider.GetWallpaperInfo();
 
-            testContext.WriteLine("Author: " + wallpaper.Author);
-            testContext.WriteLine("Author URI: " + wallpaper.AuthorUri);
-            testContext.WriteLine("Description: " + wallpaper.Description);
-            testContext.WriteLine("Image URI: " + wallpaper.ImageUri);
-            testContext.WriteLine("Title: " + wallpaper.Title);
-            testContext.WriteLine("Title Uri: " + wallpaper.TitleUri);
+            TestContext.WriteLine("Author: " + wallpaper.Author);
+            TestContext.WriteLine("Author URI: " + wallpaper.AuthorUri);
+            TestContext.WriteLine("Description: " + wallpaper.Description);
+            TestContext.WriteLine("Image URI: " + wallpaper.ImageUri);
+            TestContext.WriteLine("Title: " + wallpaper.Title);
+            TestContext.WriteLine("Title Uri: " + wallpaper.TitleUri);
 
             Assert.IsFalse(string.IsNullOrWhiteSpace(wallpaper.Author), "Null/whitespace author.");
             Assert.IsFalse(string.IsNullOrWhiteSpace(wallpaper.AuthorUri), "Null/whitespace author URI.");
@@ -198,12 +196,12 @@ namespace DailyDesktop.Tests
             var provider = new WikimediaCommonsProvider();
             var wallpaper = await provider.GetWallpaperInfo();
 
-            testContext.WriteLine("Author: " + wallpaper.Author);
-            testContext.WriteLine("Author URI: " + wallpaper.AuthorUri);
-            testContext.WriteLine("Description: " + wallpaper.Description);
-            testContext.WriteLine("Image URI: " + wallpaper.ImageUri);
-            testContext.WriteLine("Title: " + wallpaper.Title);
-            testContext.WriteLine("Title Uri: " + wallpaper.TitleUri);
+            TestContext.WriteLine("Author: " + wallpaper.Author);
+            TestContext.WriteLine("Author URI: " + wallpaper.AuthorUri);
+            TestContext.WriteLine("Description: " + wallpaper.Description);
+            TestContext.WriteLine("Image URI: " + wallpaper.ImageUri);
+            TestContext.WriteLine("Title: " + wallpaper.Title);
+            TestContext.WriteLine("Title Uri: " + wallpaper.TitleUri);
 
             Assert.IsFalse(string.IsNullOrWhiteSpace(wallpaper.Author), "Null/whitespace author.");
             Assert.IsFalse(string.IsNullOrWhiteSpace(wallpaper.AuthorUri), "Null/whitespace author URI.");
@@ -219,9 +217,9 @@ namespace DailyDesktop.Tests
             var provider = new XkcdProvider();
             var wallpaper = await provider.GetWallpaperInfo();
 
-            testContext.WriteLine("Image URI: " + wallpaper.ImageUri);
-            testContext.WriteLine("Title: " + wallpaper.Title);
-            testContext.WriteLine("Title Uri: " + wallpaper.TitleUri);
+            TestContext.WriteLine("Image URI: " + wallpaper.ImageUri);
+            TestContext.WriteLine("Title: " + wallpaper.Title);
+            TestContext.WriteLine("Title Uri: " + wallpaper.TitleUri);
 
             Assert.IsFalse(string.IsNullOrWhiteSpace(wallpaper.ImageUri), "Null/whitespace image URI!");
             Assert.IsFalse(string.IsNullOrWhiteSpace(wallpaper.Title), "Null/whitespace title.");

--- a/DailyDesktop.Tests/TestProviders.cs
+++ b/DailyDesktop.Tests/TestProviders.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Alden Wu <aldenwu0@gmail.com>. Licensed under the MIT Licence.
 // See the LICENSE file in the repository root for full licence text.
 
+using System;
 using System.Threading.Tasks;
 using DailyDesktop.Core.Providers;
 using DailyDesktop.Providers.Bing;
@@ -19,7 +20,18 @@ namespace DailyDesktop.Tests
     [TestClass]
     public class TestProviders
     {
-        public TestContext TestContext { get; set; }
+        public TestContext? TestContext { get; set; }
+
+        private TestContext context
+        {
+            get
+            {
+                if (TestContext == null)
+                    throw new NullReferenceException("Null test context");
+
+                return TestContext;
+            }
+        }
 
         [TestMethod]
         public async Task TestBing()
@@ -27,11 +39,11 @@ namespace DailyDesktop.Tests
             var provider = new BingProvider();
             var wallpaper = await provider.GetWallpaperInfo();
 
-            TestContext.WriteLine("Author: " + wallpaper.Author);
-            TestContext.WriteLine("Description: " + wallpaper.Description);
-            TestContext.WriteLine("Image URI: " + wallpaper.ImageUri);
-            TestContext.WriteLine("Title: " + wallpaper.Title);
-            TestContext.WriteLine("Title Uri: " + wallpaper.TitleUri);
+            context.WriteLine("Author: " + wallpaper.Author);
+            context.WriteLine("Description: " + wallpaper.Description);
+            context.WriteLine("Image URI: " + wallpaper.ImageUri);
+            context.WriteLine("Title: " + wallpaper.Title);
+            context.WriteLine("Title Uri: " + wallpaper.TitleUri);
 
             Assert.IsFalse(string.IsNullOrWhiteSpace(wallpaper.Author), "Null/whitespace author.");
             Assert.IsFalse(string.IsNullOrWhiteSpace(wallpaper.Description), "Null/whitespace description.");
@@ -46,8 +58,8 @@ namespace DailyDesktop.Tests
             var provider = new CalvinAndHobbesProvider();
             var wallpaper = await provider.GetWallpaperInfo();
 
-            TestContext.WriteLine("Image URI: " + wallpaper.ImageUri);
-            TestContext.WriteLine("Title Uri: " + wallpaper.TitleUri);
+            context.WriteLine("Image URI: " + wallpaper.ImageUri);
+            context.WriteLine("Title Uri: " + wallpaper.TitleUri);
 
             Assert.IsFalse(string.IsNullOrWhiteSpace(wallpaper.ImageUri), "Null/whitespace image URI!");
             Assert.IsFalse(string.IsNullOrWhiteSpace(wallpaper.TitleUri), "Null/whitespace title URI.");
@@ -59,12 +71,12 @@ namespace DailyDesktop.Tests
         //     var provider = new DeviantArtProvider();
         //     var wallpaper = await provider.GetWallpaperInfo();
 
-        //     TestContext.WriteLine("Image URI: " + wallpaper.ImageUri);
-        //     TestContext.WriteLine("Author: " + wallpaper.Author);
-        //     TestContext.WriteLine("Author URI: " + wallpaper.AuthorUri);
-        //     TestContext.WriteLine("Title: " + wallpaper.Title);
-        //     TestContext.WriteLine("Title Uri: " + wallpaper.TitleUri);
-        //     TestContext.WriteLine("Description: " + wallpaper.Description);
+        //     context.WriteLine("Image URI: " + wallpaper.ImageUri);
+        //     context.WriteLine("Author: " + wallpaper.Author);
+        //     context.WriteLine("Author URI: " + wallpaper.AuthorUri);
+        //     context.WriteLine("Title: " + wallpaper.Title);
+        //     context.WriteLine("Title Uri: " + wallpaper.TitleUri);
+        //     context.WriteLine("Description: " + wallpaper.Description);
 
         //     Assert.IsFalse(string.IsNullOrWhiteSpace(wallpaper.ImageUri), "Null/whitespace image URI!");
         //     Assert.IsFalse(string.IsNullOrWhiteSpace(wallpaper.Author), "Null/whitespace author.");
@@ -80,10 +92,10 @@ namespace DailyDesktop.Tests
             var provider = new FalseKneesProvider();
             var wallpaper = await provider.GetWallpaperInfo();
 
-            TestContext.WriteLine("Description: " + wallpaper.Description);
-            TestContext.WriteLine("Image URI: " + wallpaper.ImageUri);
-            TestContext.WriteLine("Title: " + wallpaper.Title);
-            TestContext.WriteLine("Title Uri: " + wallpaper.TitleUri);
+            context.WriteLine("Description: " + wallpaper.Description);
+            context.WriteLine("Image URI: " + wallpaper.ImageUri);
+            context.WriteLine("Title: " + wallpaper.Title);
+            context.WriteLine("Title Uri: " + wallpaper.TitleUri);
 
             Assert.IsFalse(string.IsNullOrWhiteSpace(wallpaper.Description), "Null/whitespace description.");
             Assert.IsFalse(string.IsNullOrWhiteSpace(wallpaper.ImageUri), "Null/whitespace image URI!");
@@ -98,11 +110,11 @@ namespace DailyDesktop.Tests
         //     var provider = new MTGProvider();
         //     var wallpaper = await provider.GetWallpaperInfo();
 
-        //     TestContext.WriteLine("Image URI: " + wallpaper.ImageUri);
-        //     TestContext.WriteLine("Author: " + wallpaper.Author);
-        //     TestContext.WriteLine("Title: " + wallpaper.Title);
-        //     TestContext.WriteLine("Title Uri: " + wallpaper.TitleUri);
-        //     TestContext.WriteLine("Description: " + wallpaper.Description);
+        //     context.WriteLine("Image URI: " + wallpaper.ImageUri);
+        //     context.WriteLine("Author: " + wallpaper.Author);
+        //     context.WriteLine("Title: " + wallpaper.Title);
+        //     context.WriteLine("Title Uri: " + wallpaper.TitleUri);
+        //     context.WriteLine("Description: " + wallpaper.Description);
 
         //     Assert.IsFalse(string.IsNullOrWhiteSpace(wallpaper.ImageUri), "Null/whitespace image URI!");
         //     Assert.IsFalse(string.IsNullOrWhiteSpace(wallpaper.Author), "Null/whitespace author.");
@@ -117,12 +129,12 @@ namespace DailyDesktop.Tests
             var provider = new PixivProvider();
             var wallpaper = await provider.GetWallpaperInfo();
 
-            TestContext.WriteLine("Author: " + wallpaper.Author);
-            TestContext.WriteLine("Author URI: " + wallpaper.AuthorUri);
-            TestContext.WriteLine("Description: " + wallpaper.Description);
-            TestContext.WriteLine("Image URI: " + wallpaper.ImageUri);
-            TestContext.WriteLine("Title: " + wallpaper.Title);
-            TestContext.WriteLine("Title Uri: " + wallpaper.TitleUri);
+            context.WriteLine("Author: " + wallpaper.Author);
+            context.WriteLine("Author URI: " + wallpaper.AuthorUri);
+            context.WriteLine("Description: " + wallpaper.Description);
+            context.WriteLine("Image URI: " + wallpaper.ImageUri);
+            context.WriteLine("Title: " + wallpaper.Title);
+            context.WriteLine("Title Uri: " + wallpaper.TitleUri);
 
             Assert.IsFalse(string.IsNullOrWhiteSpace(wallpaper.Author), "Null/whitespace author.");
             Assert.IsFalse(string.IsNullOrWhiteSpace(wallpaper.AuthorUri), "Null/whitespace author URI.");
@@ -138,10 +150,10 @@ namespace DailyDesktop.Tests
             var provider = new PokemonProvider();
             var wallpaper = await provider.GetWallpaperInfo();
 
-            TestContext.WriteLine("Description: " + wallpaper.Description);
-            TestContext.WriteLine("Image URI: " + wallpaper.ImageUri);
-            TestContext.WriteLine("Title: " + wallpaper.Title);
-            TestContext.WriteLine("Title Uri: " + wallpaper.TitleUri);
+            context.WriteLine("Description: " + wallpaper.Description);
+            context.WriteLine("Image URI: " + wallpaper.ImageUri);
+            context.WriteLine("Title: " + wallpaper.Title);
+            context.WriteLine("Title Uri: " + wallpaper.TitleUri);
 
             Assert.IsFalse(string.IsNullOrWhiteSpace(wallpaper.Description), "Null/whitespace description.");
             Assert.IsFalse(string.IsNullOrWhiteSpace(wallpaper.ImageUri), "Null/whitespace image URI!");
@@ -155,11 +167,11 @@ namespace DailyDesktop.Tests
             var provider = new RedditEarthPornProvider();
             var wallpaper = await provider.GetWallpaperInfo();
 
-            TestContext.WriteLine("Author: " + wallpaper.Author);
-            TestContext.WriteLine("Author URI: " + wallpaper.AuthorUri);
-            TestContext.WriteLine("Description: " + wallpaper.Description);
-            TestContext.WriteLine("Image URI: " + wallpaper.ImageUri);
-            TestContext.WriteLine("Title Uri: " + wallpaper.TitleUri);
+            context.WriteLine("Author: " + wallpaper.Author);
+            context.WriteLine("Author URI: " + wallpaper.AuthorUri);
+            context.WriteLine("Description: " + wallpaper.Description);
+            context.WriteLine("Image URI: " + wallpaper.ImageUri);
+            context.WriteLine("Title Uri: " + wallpaper.TitleUri);
 
             Assert.IsFalse(string.IsNullOrWhiteSpace(wallpaper.Author), "Null/whitespace author.");
             Assert.IsFalse(string.IsNullOrWhiteSpace(wallpaper.AuthorUri), "Null/whitespace author URI.");
@@ -174,12 +186,12 @@ namespace DailyDesktop.Tests
             var provider = new UnsplashProvider();
             var wallpaper = await provider.GetWallpaperInfo();
 
-            TestContext.WriteLine("Author: " + wallpaper.Author);
-            TestContext.WriteLine("Author URI: " + wallpaper.AuthorUri);
-            TestContext.WriteLine("Description: " + wallpaper.Description);
-            TestContext.WriteLine("Image URI: " + wallpaper.ImageUri);
-            TestContext.WriteLine("Title: " + wallpaper.Title);
-            TestContext.WriteLine("Title Uri: " + wallpaper.TitleUri);
+            context.WriteLine("Author: " + wallpaper.Author);
+            context.WriteLine("Author URI: " + wallpaper.AuthorUri);
+            context.WriteLine("Description: " + wallpaper.Description);
+            context.WriteLine("Image URI: " + wallpaper.ImageUri);
+            context.WriteLine("Title: " + wallpaper.Title);
+            context.WriteLine("Title Uri: " + wallpaper.TitleUri);
 
             Assert.IsFalse(string.IsNullOrWhiteSpace(wallpaper.Author), "Null/whitespace author.");
             Assert.IsFalse(string.IsNullOrWhiteSpace(wallpaper.AuthorUri), "Null/whitespace author URI.");
@@ -195,12 +207,12 @@ namespace DailyDesktop.Tests
             var provider = new WikimediaCommonsProvider();
             var wallpaper = await provider.GetWallpaperInfo();
 
-            TestContext.WriteLine("Author: " + wallpaper.Author);
-            TestContext.WriteLine("Author URI: " + wallpaper.AuthorUri);
-            TestContext.WriteLine("Description: " + wallpaper.Description);
-            TestContext.WriteLine("Image URI: " + wallpaper.ImageUri);
-            TestContext.WriteLine("Title: " + wallpaper.Title);
-            TestContext.WriteLine("Title Uri: " + wallpaper.TitleUri);
+            context.WriteLine("Author: " + wallpaper.Author);
+            context.WriteLine("Author URI: " + wallpaper.AuthorUri);
+            context.WriteLine("Description: " + wallpaper.Description);
+            context.WriteLine("Image URI: " + wallpaper.ImageUri);
+            context.WriteLine("Title: " + wallpaper.Title);
+            context.WriteLine("Title Uri: " + wallpaper.TitleUri);
 
             Assert.IsFalse(string.IsNullOrWhiteSpace(wallpaper.Author), "Null/whitespace author.");
             Assert.IsFalse(string.IsNullOrWhiteSpace(wallpaper.AuthorUri), "Null/whitespace author URI.");
@@ -216,9 +228,9 @@ namespace DailyDesktop.Tests
             var provider = new XkcdProvider();
             var wallpaper = await provider.GetWallpaperInfo();
 
-            TestContext.WriteLine("Image URI: " + wallpaper.ImageUri);
-            TestContext.WriteLine("Title: " + wallpaper.Title);
-            TestContext.WriteLine("Title Uri: " + wallpaper.TitleUri);
+            context.WriteLine("Image URI: " + wallpaper.ImageUri);
+            context.WriteLine("Title: " + wallpaper.Title);
+            context.WriteLine("Title Uri: " + wallpaper.TitleUri);
 
             Assert.IsFalse(string.IsNullOrWhiteSpace(wallpaper.ImageUri), "Null/whitespace image URI!");
             Assert.IsFalse(string.IsNullOrWhiteSpace(wallpaper.Title), "Null/whitespace title.");

--- a/DailyDesktop.Tests/TestProviders.cs
+++ b/DailyDesktop.Tests/TestProviders.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Alden Wu <aldenwu0@gmail.com>. Licensed under the MIT Licence.
 // See the LICENSE file in the repository root for full licence text.
 
-using System;
 using System.Threading.Tasks;
 using DailyDesktop.Core.Providers;
 using DailyDesktop.Providers.Bing;


### PR DESCRIPTION
Apparently this feature isn't actually enabled by default. It's actually the literal line of XML code `<Nullable>enable</Nullable>` that is included by default, but since this project is old, it wasn't included. I thought it was the feature itself that was enabled by default, so I didn't add these lines in during the move to .NET 6.0.