### PR TITLE
Core: Make `HttpUtils.Client` non-nullable

### DIFF
--- a/DailyDesktop.Core/Util/HttpUtils.cs
+++ b/DailyDesktop.Core/Util/HttpUtils.cs
@@ -13,8 +13,7 @@ namespace DailyDesktop.Core.Util
         /// <summary>
         /// An <see cref="HttpClient"/> singleton for use everywhere.
         /// </summary>
-        public static HttpClient Client => client ??= new HttpClient();
-        private static HttpClient? client;
+        public static readonly HttpClient Client = new HttpClient();
 
         /// <summary>
         /// Resets <see cref="Client"/>'s request headers, which includes adding


### PR DESCRIPTION
Seems like doing "lazy initialization" causes disposal issues. The `HttpClient` lingers (?) and the process never properly closes. At least, that's what I think is happening, since I can see "DailyDesktop.Desktop" stay in Task Manager after closing, and manually calling `HttpUtils.Client.Dispose()` fixes the issue. This is really janky, so I'd rather just avoid lazy initializing altogether.