### PR TITLE
Desktop: Kill process if failing to close after delay

### DIFF
--- a/DailyDesktop.Desktop/MainForm.cs
+++ b/DailyDesktop.Desktop/MainForm.cs
@@ -116,7 +116,16 @@ namespace DailyDesktop.Desktop
             stateBackgroundWorker.RunWorkerAsync();
         }
 
-        private void MainForm_FormClosing(object? sender, EventArgs e) => stateBackgroundWorker.CancelAsync();
+        private void MainForm_FormClosing(object? sender, EventArgs e)
+        {
+            stateBackgroundWorker.CancelAsync();
+            core.Dispose();
+
+            // TODO: SUPER SUPER SUPER BAD LOL WTF??
+            // investigate: maybe has something to do with ProviderStore not
+            // properly closing dlls?
+            Task.Delay(10_000).ContinueWith(_ => Process.GetCurrentProcess().Kill());
+        }
 
         private async void providerComboBox_SelectedIndexChanged(object? sender, EventArgs e)
         {

--- a/DailyDesktop.Desktop/MainForm.resx
+++ b/DailyDesktop.Desktop/MainForm.resx
@@ -2864,9 +2864,6 @@ New releases: https://github.com/goodtrailer/daily-desktop/releases
         5/8H24gfvKsP2DsAAAAASUVORK5CYII=
 </value>
   </data>
-  <metadata name="stateBackgroundWorker.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>158, 17</value>
-  </metadata>
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         AAABAA0AAAAAAAEAIACMJQAA1gAAAICAAAABACAAKAgBAGImAACAgAAAAQAIAChMAACKLgEAQEAAAAEA


### PR DESCRIPTION
This is very bad. It is a temporary bad fix for a bizarre bug where certain internal worker threads (.NET ThreadPool Gate and .NET Events Thread) just refuse to close if the wallpaper has been updated. I have no idea what causes this. This bug is still trigger-able after disabling any communication between Task and Desktop (removing `backgroundStateWorker`, `static HttpClient Client`, etc.) and then manually executing Task.exe through a separate shell, with the output file (`--json` option) being different from the one used by Desktop. ???? Clearly there is some unwanted connection between Task and Desktop going on here, but I really cannot see what it is.