### PR TITLE
Core: Remove sync duplicate methods

### DIFF
--- a/DailyDesktop.Core/Configuration/IPublicNullableConfiguration.cs
+++ b/DailyDesktop.Core/Configuration/IPublicNullableConfiguration.cs
@@ -13,13 +13,6 @@ namespace DailyDesktop.Core.Configuration
     public interface IPublicNullableConfiguration
     {
         /// <summary>
-        /// Nullifies all <see cref="string"/> properties that satisfy
-        /// <see cref="string.IsNullOrWhiteSpace(string?)"/>.
-        /// </summary>
-        /// <returns>The number of properties that were nullified.</returns>
-        int NullifyWhitespace();
-
-        /// <summary>
         /// Asynchronously nullifies all <see cref="string"/> properties that satisfy
         /// <see cref="string.IsNullOrWhiteSpace(string?)"/>.
         /// </summary>

--- a/DailyDesktop.Core/Configuration/IPublicPathConfiguration.cs
+++ b/DailyDesktop.Core/Configuration/IPublicPathConfiguration.cs
@@ -13,21 +13,6 @@ namespace DailyDesktop.Core.Configuration
     public interface IPublicPathConfiguration : IReadOnlyPathConfiguration
     {
         /// <summary>
-        /// The assembly directory (e.g. for the task executable).
-        /// </summary>
-        new string AssemblyDir { get; set; }
-
-        /// <summary>
-        /// The providers directory (e.g. for <see cref="IProvider"/> DLL modules).
-        /// </summary>
-        new string ProvidersDir { get; set; }
-
-        /// <summary>
-        /// The serialization directory (e.g. for the <see cref="TaskConfiguration"/> JSON).
-        /// </summary>
-        new string SerializationDir { get; set; }
-
-        /// <summary>
         /// Asynchronously sets the assembly directory (e.g. for the task executable).
         /// </summary>
         /// <param name="assemblyDir">The value to set as.</param>

--- a/DailyDesktop.Core/Configuration/IPublicTaskConfiguration.cs
+++ b/DailyDesktop.Core/Configuration/IPublicTaskConfiguration.cs
@@ -14,39 +14,6 @@ namespace DailyDesktop.Core.Configuration
     public interface IPublicTaskConfiguration : IReadOnlyTaskConfiguration
     {
         /// <summary>
-        /// The path of the <see cref="IProvider"/> DLL module.
-        /// </summary>
-        new string Dll { get; set; }
-
-        /// <summary>
-        /// Whether wallpaper update <see cref="Microsoft.Win32.TaskScheduler.Task"/> triggers are
-        /// enabled or disabled.
-        /// </summary>
-        new bool IsEnabled { get; set; }
-
-        /// <summary>
-        /// The time at which the daily wallpaper update trigger executes. Only applies if
-        /// <see cref="IsEnabled"/> is set to <c>true</c>.
-        /// </summary>
-        new DateTime UpdateTime { get; set; }
-
-        /// <summary>
-        /// Whether or not to apply resize to wallpaper images to screen resolution, if larger.
-        /// </summary>
-        new bool DoResize { get; set; }
-
-        /// <summary>
-        /// Whether or not to apply blurred-fit to wallpaper images.
-        /// </summary>
-        new bool DoBlurredFit { get; set; }
-
-        /// <summary>
-        /// The blur strength for wallpaper images. Only applies if
-        /// <see cref="DoBlurredFit"/> is set to <c>true</c>.
-        /// </summary>
-        new int BlurStrength { get; set; }
-
-        /// <summary>
         /// Sets the path of the <see cref="IProvider"/> DLL module.
         /// </summary>
         /// <param name="dll">The value to set as.</param>
@@ -63,7 +30,7 @@ namespace DailyDesktop.Core.Configuration
 
         /// <summary>
         /// Sets the time at which the daily wallpaper update trigger executes. Only applies if
-        /// <see cref="IsEnabled"/> is set to <c>true</c>.
+        /// <see cref="IReadOnlyTaskConfiguration.IsEnabled"/> is <c>true</c>.
         /// </summary>
         /// <param name="updateTime">The value to set as.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
@@ -85,7 +52,7 @@ namespace DailyDesktop.Core.Configuration
 
         /// <summary>
         /// Sets the blur strength for wallpaper images. Only applies if
-        /// <see cref="DoBlurredFit"/> is set to <c>true</c>.
+        /// <see cref="IReadOnlyTaskConfiguration.DoBlurredFit"/> is set to <c>true</c>.
         /// </summary>
         /// <param name="blurStrength">The value to set as.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>

--- a/DailyDesktop.Core/Configuration/IPublicWallpaperConfiguration.cs
+++ b/DailyDesktop.Core/Configuration/IPublicWallpaperConfiguration.cs
@@ -12,36 +12,6 @@ namespace DailyDesktop.Core.Configuration
     public interface IPublicWallpaperConfiguration : IReadOnlyWallpaperConfiguration, IPublicNullableConfiguration
     {
         /// <summary>
-        /// The URI of the image file. Cannot be null because there must be an image is necessary.
-        /// </summary>
-        new string ImageUri { get; set; }
-
-        /// <summary>
-        /// The author of the work (i.e. the illustrator, photographer, painter, etc.)
-        /// </summary>
-        new string? Author { get; set; }
-
-        /// <summary>
-        /// A URI to the <see cref="Author"/>. Usually a URL to the author's website or profile page.
-        /// </summary>
-        new string? AuthorUri { get; set; }
-
-        /// <summary>
-        /// The title of the work.
-        /// </summary>
-        new string? Title { get; set; }
-
-        /// <summary>
-        /// A URI to the work. Usually a URL to the image's page on the source website where it was downloaded from.
-        /// </summary>
-        new string? TitleUri { get; set; }
-
-        /// <summary>
-        /// A description for the work.
-        /// </summary>
-        new string? Description { get; set; }
-
-        /// <summary>
         /// Asynchronously sets the URI of the image file. Cannot be null because there must be an image is necessary.
         /// </summary>
         /// <param name="imageUri">The value to set as.</param>
@@ -56,7 +26,7 @@ namespace DailyDesktop.Core.Configuration
         Task SetAuthorAsync(string? author, CancellationToken cancellationToken);
 
         /// <summary>
-        /// Asynchronously sets the URI to the <see cref="Author"/>. Usually a URL to the author's website or profile page.
+        /// Asynchronously sets the URI to the <see cref="IReadOnlyWallpaperConfiguration.Author"/>. Usually a URL to the author's website or profile page.
         /// </summary>
         /// <param name="authorUri">The value to set as.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>

--- a/DailyDesktop.Core/Configuration/IReadOnlyConfiguration.cs
+++ b/DailyDesktop.Core/Configuration/IReadOnlyConfiguration.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Alden Wu <aldenwu0@gmail.com>. Licensed under the MIT Licence.
 // See the LICENSE file in the repository root for full licence text.
 
-using System;
 using System.Threading;
 using System.Threading.Tasks;
 using DailyDesktop.Core.Util;
@@ -24,30 +23,14 @@ namespace DailyDesktop.Core.Configuration
         bool IsAutoSerializing { get; }
 
         /// <summary>
-        /// Event published on calls to <see cref="Update"/>.
-        /// </summary>
-        event EventHandler OnUpdate;
-
-        /// <summary>
         /// Asynchronous event published on calls to <see cref="UpdateAsync"/>.
         /// </summary>
         event AsyncEventHandler OnUpdateAsync;
 
         /// <summary>
-        /// Event published on successful calls to <see cref="Serialize"/>.
-        /// </summary>
-        event EventHandler OnSerialize;
-
-        /// <summary>
         /// Asynchronous event published on successful calls to <see cref="SerializeAsync"/>.
         /// </summary>
         event AsyncEventHandler OnSerializeAsync;
-
-        /// <summary>
-        /// Automatically called upon setting properties. Can be called manually to
-        /// publish to <see cref="OnUpdateAsync"/> and serialize (in case <see cref="IsAutoSerializing"/> is true).
-        /// </summary>
-        void Update();
 
         /// <summary>
         /// Automatically called upon setting properties. Can be called manually to asynchronously
@@ -56,22 +39,9 @@ namespace DailyDesktop.Core.Configuration
         Task UpdateAsync(CancellationToken cancellationToken);
 
         /// <summary>
-        /// Serialize configuration to a JSON file (located at <see cref="JsonPath"/>).
-        /// </summary>
-        void Serialize();
-
-        /// <summary>
         /// Asynchronously serialize configuration to a JSON file (located at <see cref="JsonPath"/>).
         /// </summary>
         Task SerializeAsync(CancellationToken cancellationToken);
-
-        /// <summary>
-        /// Try to serialize configuration to a JSON file (located at <see cref="JsonPath"/>).
-        /// </summary>
-        /// <returns>
-        /// Whether or not the serialiazation was successful.
-        /// </returns>
-        bool TrySerialize();
 
         /// <summary>
         /// Try to asynchronously serialize configuration to a JSON file (located at <see cref="JsonPath"/>).

--- a/DailyDesktop.Core/Configuration/PathConfiguration.cs
+++ b/DailyDesktop.Core/Configuration/PathConfiguration.cs
@@ -6,7 +6,6 @@ using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Web;
-using DailyDesktop.Core.Util;
 
 namespace DailyDesktop.Core.Configuration
 {
@@ -22,61 +21,25 @@ namespace DailyDesktop.Core.Configuration
         }
 
         /// <inheritdoc/>
-        public string AssemblyDir
-        {
-            get => assemblyDir;
-            set
-            {
-                if (assemblyDir == value)
-                    return;
-
-                Directory.CreateDirectory(value);
-                assemblyDir = value;
-                UpdateAsync(default).Wait(AsyncUtils.TimedCancel());
-            }
-        }
+        public string AssemblyDir { get => assemblyDir; init => assemblyDir = value; }
 
         /// <inheritdoc/>
-        public string ProvidersDir
-        {
-            get => providersDir;
-            set
-            {
-                if (providersDir == value)
-                    return;
-
-                Directory.CreateDirectory(value);
-                providersDir = value;
-                UpdateAsync(default).Wait(AsyncUtils.TimedCancel());
-            }
-        }
+        public string ProvidersDir { get => providersDir; init => providersDir = value; }
 
         /// <inheritdoc/>
-        public string SerializationDir
-        {
-            get => serializationDir;
-            set
-            {
-                if (serializationDir == value)
-                    return;
-
-                Directory.CreateDirectory(value);
-                serializationDir = value;
-                UpdateAsync(default).Wait(AsyncUtils.TimedCancel());
-            }
-        }
+        public string SerializationDir { get => serializationDir; init => serializationDir = value; }
 
         /// <inheritdoc/>
         [JsonIgnore]
-        public string TaskExecutable => HttpUtility.UrlDecode(Path.Combine(assemblyDir, "DailyDesktop.Task.exe"));
+        public string TaskExecutable => HttpUtility.UrlDecode(Path.Combine(AssemblyDir, "DailyDesktop.Task.exe"));
 
         /// <inheritdoc/>
         [JsonIgnore]
-        public string TaskConfigJson => HttpUtility.UrlDecode(Path.Combine(serializationDir, "settings.json"));
+        public string TaskConfigJson => HttpUtility.UrlDecode(Path.Combine(SerializationDir, "settings.json"));
 
         /// <inheritdoc/>
         [JsonIgnore]
-        public string WallpaperJson => HttpUtility.UrlDecode(Path.Combine(serializationDir, "wallpaper.json"));
+        public string WallpaperJson => HttpUtility.UrlDecode(Path.Combine(SerializationDir, "wallpaper.json"));
 
         /// <inheritdoc/>
         public async Task SetAssemblyDirAsync(string assemblyDir, CancellationToken cancellationToken)

--- a/DailyDesktop.Core/Configuration/TaskConfiguration.cs
+++ b/DailyDesktop.Core/Configuration/TaskConfiguration.cs
@@ -19,88 +19,22 @@ namespace DailyDesktop.Core.Configuration
         }
 
         /// <inheritdoc/>
-        public string Dll
-        {
-            get => dll;
-            set
-            {
-                if (dll == value)
-                    return;
-
-                dll = value;
-                Update();
-            }
-        }
+        public string Dll { get => dll; init => dll = value; }
 
         /// <inheritdoc/>
-        public bool IsEnabled
-        {
-            get => isEnabled;
-            set
-            {
-                if (isEnabled == value)
-                    return;
-
-                isEnabled = value;
-                Update();
-            }
-        }
+        public bool IsEnabled { get => isEnabled; init => isEnabled = value; }
 
         /// <inheritdoc/>
-        public DateTime UpdateTime
-        {
-            get => updateTime;
-            set
-            {
-                if (updateTime == value)
-                    return;
-
-                updateTime = value;
-                Update();
-            }
-        }
+        public DateTime UpdateTime { get => updateTime; init => updateTime = value; }
 
         /// <inheritdoc/>
-        public bool DoResize
-        {
-            get => doResize;
-            set
-            {
-                if (doResize == value)
-                    return;
-
-                doResize = value;
-                Update();
-            }
-        }
+        public bool DoResize { get => doResize; init => doResize = value; }
 
         /// <inheritdoc/>
-        public bool DoBlurredFit
-        {
-            get => doBlurredFit;
-            set
-            {
-                if (doBlurredFit == value)
-                    return;
-
-                doBlurredFit = value;
-                Update();
-            }
-        }
+        public bool DoBlurredFit { get => doBlurredFit; init => doBlurredFit = value; }
 
         /// <inheritdoc/>
-        public int BlurStrength
-        {
-            get => blurStrength;
-            set
-            {
-                if (blurStrength == value)
-                    return;
-
-                blurStrength = value;
-                Update();
-            }
-        }
+        public int BlurStrength { get => blurStrength; init => blurStrength = value; }
 
         /// <inheritdoc/>
         public async Task SetDllAsync(string dll, CancellationToken cancellationToken)
@@ -155,7 +89,7 @@ namespace DailyDesktop.Core.Configuration
         /// <inheritdoc/>
         public async Task SetBlurStrengthAsync(int blurStrength, CancellationToken cancellationToken)
         {
-            if (this.blurStrength == blurStrength)
+            if (BlurStrength == blurStrength)
                 return;
 
             this.blurStrength = blurStrength;

--- a/DailyDesktop.Core/Configuration/WallpaperConfiguration.cs
+++ b/DailyDesktop.Core/Configuration/WallpaperConfiguration.cs
@@ -19,142 +19,25 @@ namespace DailyDesktop.Core.Configuration
         }
 
         /// <inheritdoc/>
-        public string ImageUri
-        {
-            get => imageUri;
-            set
-            {
-                if (imageUri == value)
-                    return;
-
-                imageUri = value;
-                Update();
-            }
-        }
+        public string ImageUri { get => imageUri; init => imageUri = value; }
 
         /// <inheritdoc/>
-        public string? Author
-        {
-            get => author;
-            set
-            {
-                if (author == value)
-                    return;
-
-                author = value;
-                Update();
-            }
-        }
+        public string? Author { get => author; init => author = value; }
 
         /// <inheritdoc/>
-        public string? AuthorUri
-        {
-            get => authorUri;
-            set
-            {
-                if (authorUri == value)
-                    return;
-
-                authorUri = value;
-                Update();
-            }
-        }
+        public string? AuthorUri { get => authorUri; init => authorUri = value; }
 
         /// <inheritdoc/>
-        public string? Title
-        {
-            get => title;
-            set
-            {
-                if (title == value)
-                    return;
-
-                title = value;
-                Update();
-            }
-        }
+        public string? Title { get => title; init => title = value; }
 
         /// <inheritdoc/>
-        public string? TitleUri
-        {
-            get => titleUri;
-            set
-            {
-                if (titleUri == value)
-                    return;
-
-                titleUri = value;
-                Update();
-            }
-        }
+        public string? TitleUri { get => titleUri; init => titleUri = value; }
 
         /// <inheritdoc/>
-        public string? Description
-        {
-            get => description;
-            set
-            {
-                if (description == value)
-                    return;
-
-                description = value;
-                Update();
-            }
-        }
+        public string? Description { get => description; init => description = value; }
 
         /// <inheritdoc/>
-        public DateTime Date
-        {
-            get => date;
-            set
-            {
-                if (date == value)
-                    return;
-
-                date = value;
-                Update();
-            }
-        }
-
-        /// <inheritdoc/>
-        public int NullifyWhitespace()
-        {
-            int count = 0;
-
-            if (string.IsNullOrWhiteSpace(author))
-            {
-                author = null;
-                count++;
-            }
-
-            if (string.IsNullOrWhiteSpace(authorUri))
-            {
-                authorUri = null;
-                count++;
-            }
-
-            if (string.IsNullOrWhiteSpace(title))
-            {
-                title = null;
-                count++;
-            }
-
-            if (string.IsNullOrWhiteSpace(titleUri))
-            {
-                titleUri = null;
-                count++;
-            }
-
-            if (string.IsNullOrWhiteSpace(description))
-            {
-                description = null;
-                count++;
-            }
-
-            Update();
-
-            return count;
-        }
+        public DateTime Date { get => date; init => date = value; }
 
         /// <inheritdoc/>
         public async Task SetImageUriAsync(string imageUri, CancellationToken cancellationToken)
@@ -259,13 +142,13 @@ namespace DailyDesktop.Core.Configuration
         /// <inheritdoc/>
         protected override void LoadImpl(WallpaperConfiguration other)
         {
-            imageUri = other.imageUri;
-            author = other.author;
-            authorUri = other.authorUri;
-            title = other.title;
-            titleUri = other.titleUri;
-            description = other.description;
-            date = other.date;
+            imageUri = other.ImageUri;
+            author = other.Author;
+            authorUri = other.AuthorUri;
+            title = other.Title;
+            titleUri = other.TitleUri;
+            description = other.Description;
+            date = other.Date;
         }
 
         private string imageUri = "";

--- a/DailyDesktop.Core/Providers/IProvider.cs
+++ b/DailyDesktop.Core/Providers/IProvider.cs
@@ -79,7 +79,7 @@ namespace DailyDesktop.Core.Providers
             provider.ConfigureHttpRequestHeaders(HttpUtils.Client.DefaultRequestHeaders);
             await provider.ConfigureWallpaperAsync(HttpUtils.Client, wallpaperConfig, cancellationToken);
 
-            wallpaperConfig.NullifyWhitespace();
+            await wallpaperConfig.NullifyWhitespaceAsync(cancellationToken);
         }
     }
 }

--- a/DailyDesktop.Core/Providers/ProviderStore.cs
+++ b/DailyDesktop.Core/Providers/ProviderStore.cs
@@ -33,22 +33,6 @@ namespace DailyDesktop.Core.Providers
         public void Clear() => providers.Clear();
 
         /// <summary>
-        /// Adds one DLL module to <see cref="Providers"/>. Will not
-        /// do anything if the DLL module has already been added
-        /// before.
-        /// </summary>
-        /// <param name="dllPath">The path of the <see cref="IProvider"/> DLL module to add</param>
-        /// <returns>The <see cref="IProvider"/> implementation <see cref="Type"/>.</returns>
-        public Type Add(string dllPath)
-        {
-            if (Providers.ContainsKey(dllPath))
-                return Providers[dllPath];
-
-            var assembly = Assembly.Load(File.ReadAllBytes(dllPath));
-            return addImpl(dllPath, assembly);
-        }
-
-        /// <summary>
         /// Asynchronously adds one DLL module to <see cref="Providers"/>. Will not
         /// do anything if the DLL module has already been added
         /// before.
@@ -62,11 +46,7 @@ namespace DailyDesktop.Core.Providers
                 return Providers[dllPath];
 
             var assembly = Assembly.Load(await File.ReadAllBytesAsync(dllPath, cancellationToken));
-            return addImpl(dllPath, assembly);
-        }
-
-        private Type addImpl(string dllPath, Assembly assembly)
-        {
+            
             foreach (var type in assembly.GetTypes())
             {
                 bool isPublic = type.IsPublic;
@@ -79,29 +59,6 @@ namespace DailyDesktop.Core.Providers
             }
 
             throw new TypeLoadException($"No {nameof(IProvider)} implementation found in \"{dllPath}\".");
-        }
-
-        /// <summary>
-        /// Scans a directory for any <see cref="IProvider"/> DLL
-        /// modules and adds their paths to <see cref="Providers"/>.
-        /// </summary>
-        /// <param name="directory">The directory to scan</param>
-        public void Scan(string directory)
-        {
-            if (!Directory.Exists(directory))
-                throw new DirectoryNotFoundException($"{directory} does not exist");
-
-            foreach (var path in Directory.GetFiles(directory, PROVIDERS_SEARCH_PATTERN, SearchOption.AllDirectories))
-            {
-                try
-                {
-                    Add(path);
-                }
-                catch (SystemException se)
-                {
-                    Console.WriteLine(se.StackTrace);
-                }
-            }
         }
 
         /// <summary>

--- a/DailyDesktop.Core/Util/HttpUtils.cs
+++ b/DailyDesktop.Core/Util/HttpUtils.cs
@@ -15,7 +15,9 @@ namespace DailyDesktop.Core.Util
         /// <summary>
         /// An <see cref="HttpClient"/> singleton for use everywhere.
         /// </summary>
-        public static readonly HttpClient Client = new HttpClient();
+        public static HttpClient Client => client ??= new HttpClient();
+
+        private static HttpClient? client;
 
         /// <summary>
         /// Resets <see cref="Client"/>'s request headers, which includes adding

--- a/DailyDesktop.Desktop/MainForm.cs
+++ b/DailyDesktop.Desktop/MainForm.cs
@@ -46,7 +46,7 @@ namespace DailyDesktop.Desktop
 
         private TaskState previousState;
 
-        public static async Task<MainForm> CreateFormAsync()
+        public static async Task<MainForm> CreateFormAsync(CancellationToken cancellationToken)
         {
             string userId = System.Security.Principal.WindowsIdentity.GetCurrent().Name;
             string userName = userId.Split('\\').Last();
@@ -66,7 +66,7 @@ namespace DailyDesktop.Desktop
                 AssemblyDir = assemblyDir,
                 ProvidersDir = providersDir,
                 SerializationDir = serializationDir,
-            }, taskName, true, AsyncUtils.TimedCancel()));
+            }, taskName, true, cancellationToken));
         }
 
         private MainForm(DailyDesktopCore core)

--- a/DailyDesktop.Desktop/Program.cs
+++ b/DailyDesktop.Desktop/Program.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Threading.Tasks;
 using System.Windows.Forms;
+using DailyDesktop.Core.Util;
 
 namespace DailyDesktop.Desktop
 {
@@ -18,7 +19,7 @@ namespace DailyDesktop.Desktop
             Application.SetHighDpiMode(HighDpiMode.SystemAware);
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
-            Application.Run(await MainForm.CreateFormAsync());
+            Application.Run(await MainForm.CreateFormAsync(AsyncUtils.TimedCancel(3_500)));
         }
     }
 }

--- a/DailyDesktop.Providers.CalvinAndHobbes/CalvinAndHobbesProvider.cs
+++ b/DailyDesktop.Providers.CalvinAndHobbes/CalvinAndHobbesProvider.cs
@@ -23,9 +23,6 @@ namespace DailyDesktop.Providers.CalvinAndHobbes
 
         public async Task ConfigureWallpaperAsync(HttpClient client, IPublicWallpaperConfiguration wallpaperConfig, CancellationToken cancellationToken)
         {
-            wallpaperConfig.Author = AUTHOR;
-            wallpaperConfig.Title = TITLE;
-
             string pageHtml = await client.GetStringAsync(SourceUri, cancellationToken);
 
             string imageUri = Regex.Match(pageHtml, IMAGE_URI_PATTERN).Value;


### PR DESCRIPTION
Fixes #69

The configuration classes are getting quite complicated. A property class could help, but making one would be a bit tricky.