### PR TITLE
FalseKnees: Fix image URI pattern

### DIFF
--- a/DailyDesktop.Providers.FalseKnees/FalseKneesProvider.cs
+++ b/DailyDesktop.Providers.FalseKnees/FalseKneesProvider.cs
@@ -14,7 +14,7 @@ namespace DailyDesktop.Providers.FalseKnees
     {
         private const string AUTHOR = "Joshua Barkman";
         private const string AUTHOR_URI = "https://falseknees.com/about.html";
-        private const string IMAGE_RELATIVE_URI_PATTERN = "imgs/[0-9]*?\\.png";
+        private const string IMAGE_RELATIVE_URI_PATTERN = "imgs/[0-9]*?\\.[a-zA-Z]+";
         private const string TITLE_RELATIVE_URI_PATTERN = "(?<=URL=)[0-9]+\\.[a-zA-Z]+";
         private const string DESCRIPTION_PATTERN = "(?<=<img.*title=\").*?(?=\")";
         private const string TITLE_PATTERN = "(?<=index\\.html.*- ).*?(?=<)";


### PR DESCRIPTION
Addresses #77.

Fixes the broken pattern, but doesn't totally fix the problem. Still needs WEBP support.