### PR TITLE
Core: Cancel previous operation to update Task

### DIFF
--- a/DailyDesktop.Core/DailyDesktopCore.cs
+++ b/DailyDesktop.Core/DailyDesktopCore.cs
@@ -181,10 +181,23 @@ namespace DailyDesktop.Core
             };
         }
 
+        private CancellationTokenSource? previousTokenSource;
+
         private async Task onTaskConfigUpdateAsync(object? sender, EventArgs? args, CancellationToken cancellationToken)
         {
             if (IsAutoCreatingTask)
-                await Task.Run(CreateTask, cancellationToken);
+            {
+                try
+                {
+                    previousTokenSource?.Cancel();
+                    previousTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                    await Task.Run(CreateTask, previousTokenSource.Token);
+                }
+                catch (OperationCanceledException)
+                {
+                    Console.WriteLine("Win32 Task update operation cancelled.");
+                }
+            }
         }
 
         /// <summary>

--- a/DailyDesktop.Core/Providers/ProviderStore.cs
+++ b/DailyDesktop.Core/Providers/ProviderStore.cs
@@ -74,8 +74,7 @@ namespace DailyDesktop.Core.Providers
 
             foreach (var path in Directory.GetFiles(directory, PROVIDERS_SEARCH_PATTERN, SearchOption.AllDirectories))
             {
-                if (cancellationToken.IsCancellationRequested)
-                    throw new OperationCanceledException();
+                cancellationToken.ThrowIfCancellationRequested();
 
                 try
                 {

--- a/DailyDesktop.Core/Util/AsyncEventHandler.cs
+++ b/DailyDesktop.Core/Util/AsyncEventHandler.cs
@@ -50,7 +50,10 @@ namespace DailyDesktop.Core.Util
                 return;
 
             foreach (var d in delegates)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
                 await d.Invoke(sender, args, cancellationToken);
+            }
         }
 
         /// <summary>

--- a/DailyDesktop.Desktop/MainForm.Designer.cs
+++ b/DailyDesktop.Desktop/MainForm.Designer.cs
@@ -408,6 +408,8 @@ namespace DailyDesktop.Desktop
             this.optionsBlurStrengthTrackBar.TabIndex = 5;
             this.optionsBlurStrengthTrackBar.TickFrequency = 10;
             this.optionsBlurStrengthTrackBar.Scroll += new System.EventHandler(this.optionsBlurStrengthTrackBar_Scroll);
+            this.optionsBlurStrengthTrackBar.MouseUp += new System.Windows.Forms.MouseEventHandler(this.optionsBlurStrengthTrackBar_MouseUp);
+            this.optionsBlurStrengthTrackBar.KeyUp += new System.Windows.Forms.KeyEventHandler(this.optionsBlurStrengthTrackBar_KeyUp);
             // 
             // optionsBlurStrengthLabel
             // 

--- a/DailyDesktop.Desktop/MainForm.cs
+++ b/DailyDesktop.Desktop/MainForm.cs
@@ -45,6 +45,8 @@ namespace DailyDesktop.Desktop
         private IPublicTaskConfiguration taskConfig => core.TaskConfig;
 
         private TaskState previousState;
+        
+        private bool isMovingBlurStrengthTrackBar;
 
         public static async Task<MainForm> CreateFormAsync(CancellationToken cancellationToken)
         {
@@ -103,19 +105,22 @@ namespace DailyDesktop.Desktop
         {
             await repopulateProviderComboBox();
 
-            optionsEnabledCheckBox.Checked = taskConfig.IsEnabled;
+            Invoke(() =>
+            {
+                optionsEnabledCheckBox.Checked = taskConfig.IsEnabled;
 
-            optionsUpdateTimePicker.Value = taskConfig.UpdateTime;
-            optionsUpdateTimePicker.Enabled = optionsEnabledCheckBox.Checked;
+                optionsUpdateTimePicker.Value = taskConfig.UpdateTime;
+                optionsUpdateTimePicker.Enabled = optionsEnabledCheckBox.Checked;
 
-            optionsResizeCheckBox.Checked = taskConfig.DoResize;
+                optionsResizeCheckBox.Checked = taskConfig.DoResize;
 
-            optionsBlurredFitCheckBox.Checked = taskConfig.DoBlurredFit;
-            optionsBlurStrengthTrackBar.Value = taskConfig.BlurStrength;
-            optionsBlurStrengthTrackBar.Enabled = optionsBlurredFitCheckBox.Checked;
-            updateBlurStrengthToolTip();
+                optionsBlurredFitCheckBox.Checked = taskConfig.DoBlurredFit;
+                optionsBlurStrengthTrackBar.Value = taskConfig.BlurStrength;
+                optionsBlurStrengthTrackBar.Enabled = optionsBlurredFitCheckBox.Checked;
+                updateBlurStrengthToolTip();
 
-            stateBackgroundWorker.RunWorkerAsync();
+                stateBackgroundWorker.RunWorkerAsync();
+            });
         }
 
         private void MainForm_FormClosing(object? sender, EventArgs e)
@@ -192,18 +197,18 @@ namespace DailyDesktop.Desktop
         private async void optionsEnabledCheckBox_CheckedChanged(object? sender, EventArgs e)
         {
             await taskConfig.SetIsEnabledAsync(optionsEnabledCheckBox.Checked, AsyncUtils.TimedCancel());
-            optionsUpdateTimePicker.Enabled = optionsEnabledCheckBox.Checked;
+            Invoke(() => optionsUpdateTimePicker.Enabled = optionsEnabledCheckBox.Checked);
         }
 
         private void optionsUpdateWallpaperButton_Click(object? sender, EventArgs e) => core.UpdateWallpaper();
 
         private void optionsProvidersDirectoryButton_Click(object? sender, EventArgs e) => openUri(core.PathConfig.ProvidersDir);
 
-        private async void optionsBlurStrengthTrackBar_Scroll(object? sender, EventArgs e)
-        {
-            await taskConfig.SetBlurStrengthAsync(optionsBlurStrengthTrackBar.Value, AsyncUtils.TimedCancel());
-            updateBlurStrengthToolTip();
-        }
+        private void optionsBlurStrengthTrackBar_Scroll(object? sender, EventArgs e) => updateBlurStrengthToolTip();
+
+        private async void optionsBlurStrengthTrackBar_MouseUp(object? sender, MouseEventArgs e) => await taskConfig.SetBlurStrengthAsync(optionsBlurStrengthTrackBar.Value, AsyncUtils.TimedCancel());
+
+        private async void optionsBlurStrengthTrackBar_KeyUp(object? sender, KeyEventArgs e) => await taskConfig.SetBlurStrengthAsync(optionsBlurStrengthTrackBar.Value, AsyncUtils.TimedCancel());
 
         private void updateBlurStrengthToolTip()
         {
@@ -214,7 +219,7 @@ namespace DailyDesktop.Desktop
         private async void optionsBlurredFitCheckBox_CheckedChanged(object? sender, EventArgs e)
         {
             await taskConfig.SetDoBlurredFitAsync(optionsBlurredFitCheckBox.Checked, AsyncUtils.TimedCancel());
-            optionsBlurStrengthTrackBar.Enabled = optionsBlurredFitCheckBox.Checked;
+            Invoke(() => optionsBlurStrengthTrackBar.Enabled = optionsBlurredFitCheckBox.Checked);
         }
 
         private async void optionsResizeCheckBox_CheckedChanged(object? sender, EventArgs e)


### PR DESCRIPTION
Fixes #74.

Also reduces lag on the track bar by only updating the value on mouse/key up, rather than on every change.