### PR TITLE
Bing: Use Bing API to fetch image data, and increase desired resolution

### DIFF
--- a/DailyDesktop.Providers.Bing/BingProvider.cs
+++ b/DailyDesktop.Providers.Bing/BingProvider.cs
@@ -1,9 +1,10 @@
 ﻿// Copyright (c) Alden Wu <aldenwu0@gmail.com>. Licensed under the MIT Licence.
 // See the LICENSE file in the repository root for full licence text.
 
-using System.Net;
+using System.Collections.Generic;
 using System.Net.Http;
-using System.Text.RegularExpressions;
+using System.Net.Http.Json;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using DailyDesktop.Core.Configuration;
@@ -13,30 +14,51 @@ namespace DailyDesktop.Providers.Bing
 {
     public class BingProvider : IProvider
     {
-        private const string IMAGE_RELATIVE_URI_PATTERN = "(/th\\?id=)([^\"/>]*?)1920x1080.[a-z]*";
-        private const string AUTHOR_PATTERN = "(?<=(<div class=\"copyright\" id=\"copyright\">))(.*?)(?=(</div>))";
-        private const string TITLE_PATTERN = "(?<=(<meta property=\"og:title\" content=\"))(.*?)(?=(\" />))";
-        private const string TITLE_RELATIVE_URI_PATTERN = "(?<=(\"BackstageUrl\":\"))(.*?)(?=(\"))";
-        private const string DESCRIPTION_PATTERN = "(?<=(<span(.*?)id=\"iotd_desc\">))(.*?)(?=(</span>))";
-
         public string DisplayName => "Bing";
         public string Description => "Grabs Bing's featured Image of the Day, which can be found on Bing's home page.";
         public string SourceUri => "https://www.bing.com";
 
+        private struct ResponseImage
+        {
+            public ResponseImage() { }
+
+            public string Url { get; set; } = "";
+            public string CopyrightLink { get; set; } = "";
+            public string Title { get; set; } = "";
+            public string CopyrightOnly { get; set; } = "";
+            public string Desc { get; set; } = "";
+        }
+
+        private struct Response
+        {
+            public Response() { }
+
+            public List<ResponseImage> Images { get; set; } = new List<ResponseImage>();
+        }
+
         public async Task ConfigureWallpaperAsync(HttpClient client, IPublicWallpaperConfiguration wallpaperConfig, CancellationToken cancellationToken)
         {
-            string pageHtml = await client.GetStringAsync(SourceUri, cancellationToken);
+            var options = new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true
+            };
 
-            string imageRelativeUri = Regex.Match(pageHtml, IMAGE_RELATIVE_URI_PATTERN).Value;
-            if (string.IsNullOrWhiteSpace(imageRelativeUri))
+            var response = await client.GetFromJsonAsync<Response>("https://global.bing.com/HPImageArchive.aspx?format=js&idx=0&n=9&pid=hp&FORM=BEHPTB&uhd=1&uhdwidth=3840&uhdheight=2160", options, cancellationToken);
+
+            if (response.Images.Count == 0)
+                throw new ProviderException("Bing API response did not contain any images.");
+
+            var image = response.Images[0];
+
+            if (string.IsNullOrWhiteSpace(image.Url))
                 throw new ProviderException("Didn't find a relative image URI.");
 
-            string imageUri = SourceUri + imageRelativeUri;
+            string imageUri = SourceUri + image.Url;
 
-            string author = Regex.Match(pageHtml, AUTHOR_PATTERN).Value;
-            string title = Regex.Match(pageHtml, TITLE_PATTERN).Value;
-            string titleUri = SourceUri + WebUtility.HtmlDecode(Regex.Unescape(Regex.Match(pageHtml, TITLE_RELATIVE_URI_PATTERN).Value)).Replace("\"", "%22");
-            string description = "TODAY ON BING\r\n" + Regex.Match(pageHtml, DESCRIPTION_PATTERN).Value;
+            string author = image.CopyrightOnly;
+            string title = image.Title;
+            string titleUri = SourceUri + image.CopyrightLink;
+            string description = "TODAY ON BING\r\n" + image.Desc;
 
             await wallpaperConfig.SetImageUriAsync(imageUri, cancellationToken);
             await wallpaperConfig.SetAuthorAsync(author, cancellationToken);


### PR DESCRIPTION
Fixes #92.

Apparently higher resolution UHD images do exist, they just aren't easy to find. Using the Bing API it is not so hard (the query was found from here: [niumoo/bing-wallpaper](https://github.com/niumoo/bing-wallpaper)). Hopefully, using the Bing API will also make this provider more robust.