### PR TITLE
Providers: Fix Calvin and Hobbes image URI pattern

### DIFF
--- a/DailyDesktop.Providers.CalvinAndHobbes/CalvinAndHobbesProvider.cs
+++ b/DailyDesktop.Providers.CalvinAndHobbes/CalvinAndHobbesProvider.cs
@@ -12,7 +12,7 @@ namespace DailyDesktop.Providers.CalvinAndHobbes
 {
     public class CalvinAndHobbesProvider : IProvider
     {
-        private const string IMAGE_URI_PATTERN = "https://assets.amuniversal.com/.*?(?=[ \"])";
+        private const string IMAGE_URI_PATTERN = "https://featureassets.amuniversal.com/.*?(?=[ \"])";
         private const string AUTHOR = "Bill Watterson";
         private const string TITLE = "Comic strip";
         private const string TITLE_RELATIVE_URI_PATTERN = "(?<=/calvinandhobbes)[/0-9]+?(?=\")";


### PR DESCRIPTION
The assets subdomain was renamed from `assets.amuniversal.com` to `featureassets.amuniversal.com`.