### PR TITLE
Pixiv: Make image URI pattern more robust

### DIFF
--- a/DailyDesktop.Providers.Pixiv/PixivProvider.cs
+++ b/DailyDesktop.Providers.Pixiv/PixivProvider.cs
@@ -18,7 +18,6 @@ namespace DailyDesktop.Providers.Pixiv
     public class PixivProvider : IProvider
     {
         private const string IMAGE_ID_PATTERN = "(?<=data-id=\")(.*?)(?=\")";
-        private const string IMAGE_URI_PATTERN = "(?<=\"original\":\")(.*?)(?=\")";
         private const string AUTHOR_PATTERN = "(?<=((\"authorId\":\")(.*?)(\"userName\":\")))(.*?[^\\\\])(?=(\"))";
         private const string AUTHOR_ID_PATTERN = "(?<=(\"authorId\":\"))([0-9]*)";
         private const string TITLE_PATTERN = "(?<=(<meta property=\"twitter:title\" content=\"))([\\S\\s]*?[^\\\\])(?=(\">))";
@@ -53,7 +52,12 @@ namespace DailyDesktop.Providers.Pixiv
 
             string imagePageHtml = await client.GetStringAsync(titleUri, cancellationToken);
 
-            string imageUri = Regex.Match(imagePageHtml, IMAGE_URI_PATTERN).Value;
+            string imageUriPattern = "/img/[0-9]+/[0-9]+/[0-9]+/[0-9]+/[0-9]+/[0-9]+/" + imageId + "(.*?)(?=\")";
+
+            string imageUri = "https://i.pximg.net/img-original" + Regex.Match(imagePageHtml, imageUriPattern).Value;
+            int excludeBegin = imageUri.IndexOf("_p0") + "_p0".Length;
+            int excludeEnd = imageUri.IndexOf(".", excludeBegin);
+            imageUri = imageUri.Substring(0, excludeBegin) + imageUri.Substring(excludeEnd);
             if (string.IsNullOrWhiteSpace(imageUri))
                 throw new ProviderException("Didn't find an image URI.");
 

--- a/DailyDesktop.Providers.Pixiv/PixivProvider.cs
+++ b/DailyDesktop.Providers.Pixiv/PixivProvider.cs
@@ -56,7 +56,7 @@ namespace DailyDesktop.Providers.Pixiv
 
             string imageUri = "https://i.pximg.net/img-original" + Regex.Match(imagePageHtml, imageUriPattern).Value;
             int excludeBegin = imageUri.IndexOf("_p0") + "_p0".Length;
-            int excludeEnd = imageUri.IndexOf(".", excludeBegin);
+            int excludeEnd = imageUri.IndexOf('.', excludeBegin);
             imageUri = imageUri.Substring(0, excludeBegin) + imageUri.Substring(excludeEnd);
             if (string.IsNullOrWhiteSpace(imageUri))
                 throw new ProviderException("Didn't find an image URI.");


### PR DESCRIPTION
For whatever reason, the `"original": "https:/i.pximg.net/..."` field in the response JSON is sometimes just empty, i.e. the response has `"original": null`. I'm not entirely sure why this is the case, as I've not yet observed this behavior in the web browser. So this is a bit of a bandage fix.