### PR TITLE
Tests: Reduce false positives for Wikimedia Commons

### DIFF
--- a/DailyDesktop.Tests/TestProviders.cs
+++ b/DailyDesktop.Tests/TestProviders.cs
@@ -191,7 +191,8 @@ namespace DailyDesktop.Tests
             TestContext.WriteLine("Title URI: " + wallpaperConfig.TitleUri);
 
             Assert.IsFalse(string.IsNullOrWhiteSpace(wallpaperConfig.Author), "Null/whitespace author.");
-            Assert.IsFalse(string.IsNullOrWhiteSpace(wallpaperConfig.AuthorUri), "Null/whitespace author URI.");
+            // The author URI is highly unreliable, since many photo authors aren't Wikimedia users
+            // Assert.IsFalse(string.IsNullOrWhiteSpace(wallpaperConfig.AuthorUri), "Null/whitespace author URI.");
             Assert.IsFalse(string.IsNullOrWhiteSpace(wallpaperConfig.Description), "Null/whitespace description.");
             Assert.IsFalse(string.IsNullOrWhiteSpace(wallpaperConfig.ImageUri), "Null/whitespace image URI.");
             Assert.IsFalse(string.IsNullOrWhiteSpace(wallpaperConfig.Title), "Null/whitespace title.");


### PR DESCRIPTION
For years now, Wikimedia Commons has been throwing false positives on the test because of a missing author URI. But this is only because many photo authors aren't actually Wikimedia users. Plus, this info isn't particularly useful; if the 3rd-party Wikimedia Commons API ever truly breaks, then most likely *everything* should break. So this just spams my e-mail for no good reason 😅