### PR TITLE
Pixiv: Use ranking page instead of image page for data, and fall back to runner-ups

### DIFF
--- a/DailyDesktop.Providers.Pixiv/PixivProvider.cs
+++ b/DailyDesktop.Providers.Pixiv/PixivProvider.cs
@@ -2,6 +2,7 @@
 // See the LICENSE file in the repository root for full licence text.
 
 using System;
+using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -17,19 +18,18 @@ namespace DailyDesktop.Providers.Pixiv
 {
     public class PixivProvider : IProvider
     {
-        private const string IMAGE_ID_PATTERN = "(?<=data-id=\")(.*?)(?=\")";
-        private const string AUTHOR_PATTERN = "(?<=((\"authorId\":\")(.*?)(\"userName\":\")))(.*?[^\\\\])(?=(\"))";
-        private const string AUTHOR_ID_PATTERN = "(?<=(\"authorId\":\"))([0-9]*)";
-        private const string TITLE_PATTERN = "(?<=(<meta property=\"twitter:title\" content=\"))([\\S\\s]*?[^\\\\])(?=(\">))";
-        private const string DESCRIPTION_PATTERN = "(?<=(<meta property=\"twitter:description\" content=\"))([\\S\\s]*?[^\\\\])(?=(\">))";
-        private const string TAG_PATTERN = "({\"tag\")(.*?)(})";
-        private const string TAG_JP_PATTERN = "(?<=(\"tag\":\"))(.*?)(?=(\"))";
-        private const string TAG_EN_PATTERN = "(?<=(\"en\":\"))(.*?)(?=(\"))";
+        private const string IMAGE_ID_PATTERN = "(?<=(data-title=\"[^\"]+?\"(.*?)data-id=\"))(.*?)(?=\")";
+        private const string IMAGE_PATH_PATTERN = "(?<=/img-master/)(.*?)_p0";
+        private const string AUTHOR_PATTERN = "(?<=(data-title=\"[^\"]+?\"(.*?)data-user-name=\"))(.*?)(?=\")";
+        private const string AUTHOR_ID_PATTERN = "(?<=data-user-id=\")(.*?)(?=\")";
+        private const string TITLE_PATTERN = "(?<=data-title=\")[^\"]+?(?=\")";
+        private const string DESCRIPTION_PATTERN = "(?<=(summary_large_image(.*?)\"description\":\"))(.*?)(?=\")";
+        private const string TAG_PATTERN = "(?<=data-tags=\")(.*?)(?=\")";
 
         public string DisplayName => "pixiv";
         public string Description => "Fetches the illustration ranked #1 on the pixiv Overall Daily Rankings for the previous day.\r\n" +
             "Using blurred-fit mode is highly recommended due to the large variety of aspect ratios of illustrations found on pixiv.";
-        public string SourceUri => "https://www.pixiv.net/ranking.php?content=illust";
+        public string SourceUri => "https://www.pixiv.net/ranking.php?mode=daily&content=illust";
 
         public void ConfigureHttpRequestHeaders(HttpRequestHeaders headers)
         {
@@ -41,57 +41,52 @@ namespace DailyDesktop.Providers.Pixiv
             // Search for image ID of #1 illustration on daily rankings page
 
             string rankingHtml = await client.GetStringAsync(SourceUri, cancellationToken);
+            
+            string imagePath = Regex.Match(rankingHtml, IMAGE_PATH_PATTERN).Value;
+            if (string.IsNullOrWhiteSpace(imagePath))
+                throw new ProviderException("Didn't find an image path, HTML was:\"\"\"\n" + rankingHtml + "\n\"\"\"");
 
-            string imageId = Regex.Match(rankingHtml, IMAGE_ID_PATTERN).Value;
-            if (string.IsNullOrWhiteSpace(imageId))
-                throw new ProviderException("Didn't find an image ID.");
+            string[] imageUris = new[]
+            {
+                "https://i.pximg.net/img-original/" + imagePath + ".png",
+                "https://i.pximg.net/img-original/" + imagePath + ".jpg",
+            };
 
-            string titleUri = "https://www.pixiv.net/en/artworks/" + imageId;
+            string? imageUri = null;
+            foreach (string uri in imageUris)
+            {
+                var request = new HttpRequestMessage(HttpMethod.Head, uri);
+                var response = await client.SendAsync(request, cancellationToken);
+                if (response.IsSuccessStatusCode)
+                {
+                    imageUri = uri;
+                    break;
+                }
+            }
+            if (imageUri == null)
+                throw new ProviderException("None of the tried URIs worked (PNG/JPG), HTML was:\"\"\"\n" + rankingHtml + "\n\"\"\"");
+
+            string titleUri = "https://www.pixiv.net/artworks/" + Regex.Match(rankingHtml, IMAGE_ID_PATTERN).Value;
+            string authorUri = "https://www.pixiv.net/users/" + Regex.Match(rankingHtml, AUTHOR_ID_PATTERN).Value;
+            string title = Regex.Match(rankingHtml, TITLE_PATTERN).Value;
+            string author = Regex.Match(rankingHtml, AUTHOR_PATTERN).Value;
 
             // Search for wallpaper info on image page
 
             string imagePageHtml = await client.GetStringAsync(titleUri, cancellationToken);
 
-            string imageUriPattern = "(?<=\"original\":\")(.*?)" + imageId + "(.*?)(?=\")";
-
-            string imageUri = Regex.Match(imagePageHtml, imageUriPattern).Value;
-            if (string.IsNullOrWhiteSpace(imageUri))
-                throw new ProviderException("Didn't find an image URI.");
-
-            string title = Regex.Match(imagePageHtml, TITLE_PATTERN).Value;
-            string author = Regex.Match(imagePageHtml, AUTHOR_PATTERN).Value;
-            string authorUri = "https://www.pixiv.net/users/" + Regex.Match(imagePageHtml, AUTHOR_ID_PATTERN).Value;
-            var descriptionBuilder = new StringBuilder(WebUtility.HtmlDecode(Regex.Match(imagePageHtml, DESCRIPTION_PATTERN).Value));
-
-            var tagMatches = Regex.Matches(imagePageHtml, TAG_PATTERN).ToList();
-            if (tagMatches.Count > 0)
-            {
-                var tagsBuilder = new StringBuilder();
-                foreach (var tagMatch in tagMatches)
-                {
-                    if (!tagMatch.Success)
-                        continue;
-
-                    var tag = tagMatch.Value;
-
-                    string jp = Regex.Match(tag, TAG_JP_PATTERN).Value;
-                    tagsBuilder.AppendFormat("#{0} ", jp);
-
-                    string en = Regex.Match(tag, TAG_EN_PATTERN).Value;
-                    if (!string.IsNullOrWhiteSpace(en))
-                        tagsBuilder.AppendFormat("[{0}] ", en);
-                }
-
-                descriptionBuilder.Append("\n\n");
-                descriptionBuilder.Append(tagsBuilder);
-            }
+            string description = WebUtility.HtmlDecode(Regex.Matches(imagePageHtml, DESCRIPTION_PATTERN).LastOrDefault()?.Value) ?? "";
+            description = description.Replace("\\r", "\r").Replace("\\n", "\n");
+            string tags = Regex.Match(rankingHtml, TAG_PATTERN).Value;
+            if (!string.IsNullOrWhiteSpace(tags))
+                description += "\n\n" + string.Join(" ", tags.Split(" ").Select(s => "#" + s));
 
             await wallpaperConfig.SetImageUriAsync(imageUri, cancellationToken);
             await wallpaperConfig.SetAuthorAsync(author, cancellationToken);
             await wallpaperConfig.SetAuthorUriAsync(authorUri, cancellationToken);
             await wallpaperConfig.SetTitleAsync(title, cancellationToken);
             await wallpaperConfig.SetTitleUriAsync(titleUri, cancellationToken);
-            await wallpaperConfig.SetDescriptionAsync(descriptionBuilder.ToString(), cancellationToken);
+            await wallpaperConfig.SetDescriptionAsync(description, cancellationToken);
         }
     }
 }

--- a/DailyDesktop.Providers.Pixiv/PixivProvider.cs
+++ b/DailyDesktop.Providers.Pixiv/PixivProvider.cs
@@ -2,12 +2,10 @@
 // See the LICENSE file in the repository root for full licence text.
 
 using System;
-using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
-using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
@@ -41,7 +39,7 @@ namespace DailyDesktop.Providers.Pixiv
             // Search for image ID of #1 illustration on daily rankings page
 
             string rankingHtml = await client.GetStringAsync(SourceUri, cancellationToken);
-            
+
             string imagePath = Regex.Match(rankingHtml, IMAGE_PATH_PATTERN).Value;
             if (string.IsNullOrWhiteSpace(imagePath))
                 throw new ProviderException("Didn't find an image path, HTML was:\"\"\"\n" + rankingHtml + "\n\"\"\"");


### PR DESCRIPTION
Fixes #108

Apparently #108 is not the only issue (the new "logged-in users only" feature). The image page now gives almost *zero* useful information. Title, author, image ID, etc. are all not visible on the image page's HTML. This info was always rendered in through JS, but there used to be some metadata that would contain all this info. That metadata is no longer present, unfortunately. But an easy solution is to use the daily ranking page, which still has all this information.

The only downside to using the ranking page is that it is impossible to tell the format (PNG or JPG) of the original image, since the ranking page uses thumbnails that are always JPG. The solution in this PR is to send HEAD requests to both PNG and JPG URLs, hoping that one of them obtains a successful response.