### PR TITLE
Providers: Add HTML string to exception messages for easier debugging

### DIFF
--- a/DailyDesktop.Providers.CalvinAndHobbes/CalvinAndHobbesProvider.cs
+++ b/DailyDesktop.Providers.CalvinAndHobbes/CalvinAndHobbesProvider.cs
@@ -27,6 +27,8 @@ namespace DailyDesktop.Providers.CalvinAndHobbes
             string pageHtml = await client.GetStringAsync(SourceUri, cancellationToken);
 
             string imageUri = Regex.Match(pageHtml, IMAGE_URI_PATTERN).Value;
+            if (string.IsNullOrWhiteSpace(imageUri))
+                throw new ProviderException("Didn't find an image URI, HTML was:\"\"\"\n" + pageHtml + "\n\"\"\"");
 
             DateOnly date = DateOnly.FromDateTime(DateTime.Now);
             string? description = null;

--- a/DailyDesktop.Providers.DeviantArt/DeviantArtProvider.cs
+++ b/DailyDesktop.Providers.DeviantArt/DeviantArtProvider.cs
@@ -35,7 +35,7 @@ namespace DailyDesktop.Providers.DeviantArt
 
             string titleUri = Regex.Match(dailyDeviationHtml, TITLE_URI_PATTERN).Value;
             if (string.IsNullOrWhiteSpace(titleUri))
-                throw new ProviderException("Didn't find an image page URI.");
+                throw new ProviderException("Didn't find an image page URI, HTML was:\"\"\"\n" + titleUri + "\n\"\"\"");
 
             // Scrape info from image page
 
@@ -43,7 +43,7 @@ namespace DailyDesktop.Providers.DeviantArt
 
             string imageUri = Regex.Match(pageHtml, IMAGE_URI_PATTERN).Value;
             if (string.IsNullOrWhiteSpace(imageUri))
-                throw new ProviderException("Didn't find an image URI.");
+                throw new ProviderException("Didn't find an image URI, HTML was:\"\"\"\n" + pageHtml + "\n\"\"\"");
 
             string author = Regex.Match(pageHtml, AUTHOR_PATTERN).Value;
             string authorUri = Regex.Match(titleUri, "https://www.deviantart.com/.*?/").Value;

--- a/DailyDesktop.Providers.DeviantArt/DeviantArtProvider.cs
+++ b/DailyDesktop.Providers.DeviantArt/DeviantArtProvider.cs
@@ -8,7 +8,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using DailyDesktop.Core.Configuration;
 using DailyDesktop.Core.Providers;
-using static System.Net.WebRequestMethods;
 
 namespace DailyDesktop.Providers.DeviantArt
 {

--- a/DailyDesktop.Providers.MTG/MTGProvider.cs
+++ b/DailyDesktop.Providers.MTG/MTGProvider.cs
@@ -29,7 +29,7 @@ namespace DailyDesktop.Providers.MTG
 
             string imageUri = "https://" + Regex.Match(pageHtml, IMAGE_URI_PATTERN).Value;
             if (string.IsNullOrWhiteSpace(imageUri))
-                throw new ProviderException("Didn't find an image URI.");
+                throw new ProviderException("Didn't find an image URI, HTML was:\"\"\"\n" + pageHtml + "\n\"\"\"");
 
             string relevantHtml = pageHtml.Substring(Regex.Match(pageHtml, RELEVANT_SOURCE_PATTERN).Index);
             string author = Regex.Match(relevantHtml, AUTHOR_PATTERN).Value.Trim();

--- a/DailyDesktop.Providers.RedditEarthPorn/RedditEarthPornProvider.cs
+++ b/DailyDesktop.Providers.RedditEarthPorn/RedditEarthPornProvider.cs
@@ -28,7 +28,7 @@ namespace DailyDesktop.Providers.RedditEarthPorn
 
             string imageUri = Regex.Match(subredditHtml, IMAGE_URI_PATTERN).Value;
             if (string.IsNullOrWhiteSpace(imageUri))
-                throw new ProviderException("Didn't find an image URI.");
+                throw new ProviderException("Didn't find an image URI, HTML was:\"\"\"\n" + subredditHtml + "\n\"\"\"");
 
             string author = "u/" + Regex.Match(subredditHtml, AUTHOR_PATTERN).Value;
             string authorUri = "https://www.reddit.com/" + author;

--- a/DailyDesktop.Providers.Unsplash/UnsplashProvider.cs
+++ b/DailyDesktop.Providers.Unsplash/UnsplashProvider.cs
@@ -46,7 +46,7 @@ namespace DailyDesktop.Providers.Unsplash
             // Scrape info from image page
 
             string pageHtml = await client.GetStringAsync(titleUri, cancellationToken);
-            
+
             string imageUri = HttpUtility.HtmlDecode(Regex.Match(pageHtml, IMAGE_URI_PATTERN).Value);
             if (string.IsNullOrWhiteSpace(imageUri))
                 throw new ProviderException("Didn't find an image URI, HTML was:\"\"\"\n" + pageHtml + "\n\"\"\"");

--- a/DailyDesktop.Providers.Unsplash/UnsplashProvider.cs
+++ b/DailyDesktop.Providers.Unsplash/UnsplashProvider.cs
@@ -49,7 +49,7 @@ namespace DailyDesktop.Providers.Unsplash
             
             string imageUri = HttpUtility.HtmlDecode(Regex.Match(pageHtml, IMAGE_URI_PATTERN).Value);
             if (string.IsNullOrWhiteSpace(imageUri))
-                throw new ProviderException("Didn't find an image URI.");
+                throw new ProviderException("Didn't find an image URI, HTML was:\"\"\"\n" + pageHtml + "\n\"\"\"");
 
             string authorRelativeUri = Regex.Match(pageHtml, AUTHOR_RELATIVE_URI_PATTERN).Value;
             string authorUri = "https://unsplash.com" + authorRelativeUri;

--- a/DailyDesktop.Providers.WikimediaCommons/WikimediaCommonsProvider.cs
+++ b/DailyDesktop.Providers.WikimediaCommons/WikimediaCommonsProvider.cs
@@ -48,7 +48,7 @@ namespace DailyDesktop.Providers.WikimediaCommons
 
             string imageUri = Regex.Match(requestXml, IMAGE_URI_PATTERN).Value;
             if (string.IsNullOrEmpty(imageUri))
-                throw new ProviderException("Didn't find an image URI.");
+                throw new ProviderException("Didn't find an image URI, XML was:\"\"\"\n" + requestXml + "\n\"\"\"");
 
             string authorElement = Regex.Match(requestXml, AUTHOR_ELEMENT_PATTERN).Value;
             string author = Regex.Match(authorElement, AUTHOR_PATTERN).Value;


### PR DESCRIPTION
Sometimes web-scraping is unpredictable, and HTML responses change seemingly at random. Including them in the exception message (so that they appear in the desktop application as well) makes everything much easier to debug, since reproducibility is no longer necessary.